### PR TITLE
[Bug Fix] On ShadowViewMutation::Update,component does not have updated x&y cordinates

### DIFF
--- a/ReactSkia/components/RSkComponent.cpp
+++ b/ReactSkia/components/RSkComponent.cpp
@@ -69,11 +69,11 @@ void RSkComponent::updateComponentData(const ShadowView &newShadowView , const u
       component_.layoutMetrics = newShadowView.layoutMetrics;
       /* TODO : Analyze if this computation can be handled in RNS shell Layer */
       absOrigin_ =  parent_ ? (parent_->absOrigin_ + component_.layoutMetrics.frame.origin) : component_.layoutMetrics.frame.origin;
-      
-      if(layer_) {
-          RNS_PROFILE_API_OFF(componentName_ << " getPicture :", static_cast<RnsShell::PictureLayer*>(layer_.get())->setPicture(getPicture()));
-      } 
    }
+   
+   if(layer_) {
+      RNS_PROFILE_API_OFF(componentName_ << " getPicture :", static_cast<RnsShell::PictureLayer*>(layer_.get())->setPicture(getPicture()));
+   } 
 }
 
 void RSkComponent::mountChildComponent(

--- a/ReactSkia/components/RSkComponent.cpp
+++ b/ReactSkia/components/RSkComponent.cpp
@@ -65,11 +65,14 @@ void RSkComponent::updateComponentData(const ShadowView &newShadowView , const u
       component_.state = newShadowView.state;
    if(updateMask & ComponentUpdateMaskEventEmitter)
       component_.eventEmitter = newShadowView.eventEmitter;
-   if(updateMask & ComponentUpdateMaskLayoutMetrics)
+   if(updateMask & ComponentUpdateMaskLayoutMetrics) {
       component_.layoutMetrics = newShadowView.layoutMetrics;
-
-   if(layer_) {
-     RNS_PROFILE_API_OFF(componentName_ << " getPicture :", static_cast<RnsShell::PictureLayer*>(layer_.get())->setPicture(getPicture()));
+      /* TODO : Analyze if this computation can be handled in RNS shell Layer */
+      absOrigin_ =  parent_ ? (parent_->absOrigin_ + component_.layoutMetrics.frame.origin) : component_.layoutMetrics.frame.origin;
+      
+      if(layer_) {
+          RNS_PROFILE_API_OFF(componentName_ << " getPicture :", static_cast<RnsShell::PictureLayer*>(layer_.get())->setPicture(getPicture()));
+      } 
    }
 }
 


### PR DESCRIPTION
RSkComponent holds the frame origin absolute value when component mount.
This absolute frame origin is required to be updated in ShadowViewMutation Update if layout metrics is changes in shadow view.
