### PR TITLE
Shadow Props supported on ReactNativeSkia and RSKDrawUtils refactored

### DIFF
--- a/ReactSkia/components/RSkComponent.h
+++ b/ReactSkia/components/RSkComponent.h
@@ -53,8 +53,7 @@ class RSkComponent : public sk_app::Window::Layer {
 
   virtual void updateComponentData(const ShadowView &newShadowView , const uint32_t updateMask);
   Component getComponentData() { return component_;};
-  Point getFrameOrigin() { return absOrigin_;};
-  Size getFrameSize() { return component_.layoutMetrics.frame.size;};
+  Rect getAbsoluteFrame(){return Rect{absOrigin_,component_.layoutMetrics.frame.size} ;};
 
  protected:
   virtual void OnPaint(SkCanvas *canvas) = 0;

--- a/ReactSkia/components/RSkComponentImage.cpp
+++ b/ReactSkia/components/RSkComponentImage.cpp
@@ -1,14 +1,14 @@
-
 #include "ReactSkia/components/RSkComponentImage.h"
-
 #include "include/core/SkBitmap.h"
 #include "include/core/SkData.h"
 #include "include/core/SkImageGenerator.h"
 #include "include/core/SkPaint.h"
-
+#include "ReactSkia/views/common/RSkDrawUtils.h"
 #include "react/renderer/components/image/ImageShadowNode.h"
 
 #include <glog/logging.h>
+
+using namespace facebook::react::RSkDrawUtils;
 
 namespace facebook {
 namespace react {
@@ -61,20 +61,13 @@ void RSkComponentImage::OnPaint(
     auto bitmap = GetAsset(path.c_str());
     assert(bitmap);
 
-    /* apply view style props 
-     * Draw order 1. Background 2. Image 3. Border
-    */
-    Rect frame;
-    frame.origin=getFrameOrigin();
-    frame.size=getFrameSize();
+    Rect frame = getAbsoluteFrame();
+    SkRect rect = SkRect::MakeXYWH(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
     auto const &imageBorderMetrics=imageProps.resolveBorderMetrics(component.layoutMetrics);
 
+    /* Draw order 1. Background 2. Image 3. Border*/
     drawBackground(canvas,frame,imageBorderMetrics,imageProps.backgroundColor,imageProps.opacity);
-
-    SkRect rect = SkRect::MakeXYWH(
-        frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
     canvas->drawBitmapRect(*bitmap, rect, nullptr);
-
     drawBorder(canvas,frame,imageBorderMetrics,imageProps.backgroundColor,imageProps.opacity);
   }
 }

--- a/ReactSkia/components/RSkComponentImage.cpp
+++ b/ReactSkia/components/RSkComponentImage.cpp
@@ -8,10 +8,10 @@
 
 #include <glog/logging.h>
 
-using namespace facebook::react::RSkDrawUtils;
-
 namespace facebook {
 namespace react {
+
+using namespace RSkDrawUtils;
 
 namespace {
 std::unique_ptr<SkBitmap> GetAsset(const char *path) {

--- a/ReactSkia/components/RSkComponentImage.h
+++ b/ReactSkia/components/RSkComponentImage.h
@@ -1,12 +1,11 @@
 #pragma once
 
 #include "ReactSkia/components/RSkComponent.h"
-#include "ReactSkia/views/common/RSkDrawUtils.h"
 
 namespace facebook {
 namespace react {
 
-class RSkComponentImage final : public RSkComponent , public RSkDrawUtils{
+class RSkComponentImage final : public RSkComponent {
  public:
   RSkComponentImage(const ShadowView &shadowView);
 

--- a/ReactSkia/components/RSkComponentText.cpp
+++ b/ReactSkia/components/RSkComponentText.cpp
@@ -34,13 +34,11 @@ void RSkComponentParagraph::OnPaint(SkCanvas *canvas) {
       *std::static_pointer_cast<ParagraphProps const>(component.props);
   auto data = state->getData();
 
-  auto framePoint = getFrameOrigin();
-  auto frameSize = getFrameSize();
-
+  auto frame = getAbsoluteFrame();
   std::unique_ptr<skia::textlayout::Paragraph> fPara;
   /* RSkTextLayoutManager to build paragraph, set build with true to consider font decoration */
-  fPara = buildParagraph(data.attributedString , props.paragraphAttributes , frameSize ,true);
-  fPara->paint(canvas, framePoint.x, framePoint.y);
+  fPara = buildParagraph(data.attributedString , props.paragraphAttributes , frame.size ,true);
+  fPara->paint(canvas, frame.origin.x, frame.origin.y);
 
 }
 

--- a/ReactSkia/components/RSkComponentView.cpp
+++ b/ReactSkia/components/RSkComponentView.cpp
@@ -4,10 +4,10 @@
 #include "ReactSkia/views/common/RSkDrawUtils.h"
 #include <glog/logging.h>
 
-using namespace facebook::react::RSkDrawUtils;
-
 namespace facebook {
 namespace react {
+
+using namespace RSkDrawUtils;
 
 RSkComponentView::RSkComponentView(const ShadowView &shadowView)
     : RSkComponent(shadowView) {}

--- a/ReactSkia/components/RSkComponentView.cpp
+++ b/ReactSkia/components/RSkComponentView.cpp
@@ -1,9 +1,10 @@
 #include "ReactSkia/components/RSkComponentView.h"
-
 #include "include/core/SkPaint.h"
 #include "react/renderer/components/view/ViewShadowNode.h"
-
+#include "ReactSkia/views/common/RSkDrawUtils.h"
 #include <glog/logging.h>
+
+using namespace facebook::react::RSkDrawUtils;
 
 namespace facebook {
 namespace react {
@@ -14,15 +15,20 @@ RSkComponentView::RSkComponentView(const ShadowView &shadowView)
 void RSkComponentView::OnPaint(SkCanvas *canvas) {
   auto component = getComponentData();
   auto const &viewProps = *std::static_pointer_cast<ViewProps const>(component.props);
- 
   /* apply view style props */
   auto borderMetrics=viewProps.resolveBorderMetrics(component.layoutMetrics);
-  Rect frame;
-  frame.origin=getFrameOrigin();
-  frame.size=getFrameSize();
+  Rect frame = getAbsoluteFrame();
+  /*Retrieve Shadow Props*/
+  ShadowMetrics shadowMetrics{};
+  shadowMetrics.shadowColor=viewProps.shadowColor;
+  shadowMetrics.shadowOffset=viewProps.shadowOffset;
+  shadowMetrics.shadowOpacity=viewProps.shadowOpacity;
+  shadowMetrics.shadowRadius=viewProps.shadowRadius;
+
+/*Draw Order : 1. Shadow 2. BackGround 3 Border*/
+  drawShadow(canvas,frame,borderMetrics,shadowMetrics);
   drawBackground(canvas,frame,borderMetrics,viewProps.backgroundColor,viewProps.opacity);
   drawBorder(canvas,frame,borderMetrics,viewProps.backgroundColor,viewProps.opacity);
-
 }
 
 } // namespace react

--- a/ReactSkia/components/RSkComponentView.h
+++ b/ReactSkia/components/RSkComponentView.h
@@ -1,12 +1,11 @@
 #pragma once
 
 #include "ReactSkia/components/RSkComponent.h"
-#include "ReactSkia/views/common/RSkDrawUtils.h"
 
 namespace facebook {
 namespace react {
 
-class RSkComponentView final : public RSkComponent, public RSkDrawUtils{
+class RSkComponentView final : public RSkComponent {
  public:
   RSkComponentView(const ShadowView &shadowView);
 

--- a/ReactSkia/views/common/RSkDrawUtils.h
+++ b/ReactSkia/views/common/RSkDrawUtils.h
@@ -15,9 +15,14 @@
 namespace facebook {
 namespace react {
 
-class RSkDrawUtils  {
- public:
-  RSkDrawUtils();
+namespace RSkDrawUtils{
+
+struct ShadowMetrics{
+    SharedColor shadowColor{};
+    Size shadowOffset{0, 0};
+    Float shadowOpacity{0};
+    Float shadowRadius{0};
+};
 /*Function: Draw Background & Border */
   void drawBackground(SkCanvas *canvas,
                                Rect frame,
@@ -29,47 +34,11 @@ class RSkDrawUtils  {
                                BorderMetrics borderMetrics,
                                SharedColor bgColor,
                                Float opacity);
-
- private:
-  enum DrawMethod {
-     DrawFillRect ,
-     DrawRect,
-  };
-  enum BorderEdges {
-     RightEdge = 0,
-     LeftEdge,
-     TopEdge,
-     BottomEdge
-  };
-  struct PathMetrics{
-      Point outterStart{0, 0};
-      Point outterEnd{0, 0};
-      Point innerStart{0, 0};
-      Point innerEnd{0, 0};
-      Float startRadius{0};
-      Float endRadius{0};
-      Float width;
-      Float angle;
-  };
-  void setColor(SharedColor Color,Float opacity,SkPaint *paint);
-  void setStyle(int strokeWidth,SkPaint::Style Style,BorderStyle borderStyle,SkPaint *paint);
-  void setPathEffect(BorderStyle borderStyle,int strokeWidth,SkPaint *paint );
-  bool isDrawVisible(SharedColor Color,Float opacity);
-  bool hasRoundedBorders(BorderMetrics borderMetrics);
-  bool hasUniformBorderEdges(BorderMetrics borderProps);
-  void drawRect(DrawMethod drawMethod,SkCanvas *canvas,
-                                Rect frame,
+  void drawShadow(SkCanvas *canvas,
+                               Rect frame,
                                BorderMetrics borderMetrics,
-                               SharedColor Color,
-                               Float opacity);
-  void drawEdges(BorderEdges borderEdge,SkCanvas *canvas,
-                                Rect frame,
-                               BorderMetrics borderProps,
-                               SharedColor backGroundColor,
-                               Float opacity);
-void createEdge(PathMetrics pathMetrics,BorderEdges borderEdge,SkPath* path);
+                               ShadowMetrics shadowMetrics);
 
-};
-
+}//namespace RSkDrawUtils
 } // namespace react
 } // namespace facebook

--- a/packages/react-native-skia/components/view/ViewStylePropsTestApp.js
+++ b/packages/react-native-skia/components/view/ViewStylePropsTestApp.js
@@ -11,7 +11,7 @@ const SimpleViewApp = React.Node = () => {
            toggleViewState((UseCaseCount+1)%useCases);
        }, timerValue)
      
-     var baseOpacity=10;
+     var baseOpacity=0.8;
      var baseRadius=30;
      var baseWidth=20;
      var bgColor='cornflowerblue';
@@ -37,7 +37,7 @@ const SimpleViewApp = React.Node = () => {
                borderColor:borderColor,
                opacity:opacity,
                margin: 20,
-	             borderRadius:baseRadius,
+	       borderRadius:baseRadius,
            }}>
            </View> 
 }
@@ -48,7 +48,7 @@ const roundedBorderTest =(width,radius)=>{
                backgroundColor: bgColor,
                borderWidth:width,
                borderColor:borderColor,
-               opacity:baseOpacity*10,
+               opacity:baseOpacity,
                margin: 20,
                borderRadius:radius,
            }}>
@@ -71,6 +71,14 @@ const complexRoundedBorderTest =(radius,color,width)=>{
                borderRightColor:color,
                borderBottomColor:borderColor,
                borderTopColor:borderColor,
+              shadowOffset: {
+                 width: subViewWidth/2,
+                 height:subViewHeight/2
+              },
+              shadowRadius:20,
+	      shadowColor:'red',
+	      shadowOpacity: 1,
+
            }}>
            </View> 
 }
@@ -90,16 +98,14 @@ const renderMainView = () => {
                borderLeftWidth:baseWidth*3,
                borderBottomWidth:baseWidth/2,
                borderWidth:baseWidth,
-               borderRadius:0,
                borderLeftColor:'blue',
                borderRightColor:'yellow',
-               borderBottomColor:'orange',
-               borderColor:'firebrick',
+               borderTopColor:'orange',
                opacity:baseOpacity*10,
              }}>
             
-           {opacityTest(baseOpacity*2)}
-           {opacityTest(baseOpacity*5)}
+           {opacityTest(baseOpacity)}
+           {opacityTest(baseOpacity/2)}
            {opacityTest(baseOpacity*0)}
            {opacityTest(baseOpacity*8)}
 
@@ -114,7 +120,6 @@ const renderMainView = () => {
                flexDirection: 'row',
                justifyContent: 'center',
                alignItems: 'center',
-               backgroundColor:mainViewbgColor,
                borderRadius:baseRadius,
                borderColor:mainViewborderColor,
                borderWidth:baseWidth,
@@ -175,8 +180,8 @@ const renderMainView = () => {
                opacity:baseOpacity*10,
              }}>
             
-           {renderImage(baseOpacity*10)}
-           {renderImage(baseOpacity*5)}
+           {renderImage(baseOpacity)}
+           {renderImage(baseOpacity/2)}
 
            </View>)
   }
@@ -194,8 +199,8 @@ const renderMainView = () => {
                borderColor:mainViewborderColor,
                opacity:baseOpacity*10,
              }}>
-           {renderImage(baseOpacity*10)}
-           {renderImage(baseOpacity*5)}
+           {renderImage(baseOpacity/2)}
+           {renderImage(baseOpacity)}
            </View>)
    }
 


### PR DESCRIPTION
1. Supported Shadow props on React Native Skia. Props handled (shadowColor, shadowOffset, shadowOpacity, shadowRadius)
2. Refactored RSKDrawUtil to decouple it from RSKComponents.
3. Handled default value for background, border & shadow color as black.