### PR TITLE
Add support for NativeLogger and NativePerformanceNow 

### DIFF
--- a/ReactSkia/RNInstance.cpp
+++ b/ReactSkia/RNInstance.cpp
@@ -47,12 +47,20 @@ class JSCExecutorFactory : public JSExecutorFactory {
       std::shared_ptr<MessageQueueThread> jsQueue) override {
     auto installBindings = [jsiTurboModuleManager =
                                 jsiTurboModuleManager_](jsi::Runtime &runtime) {
-      // react::Logger iosLoggingBinder = [](const std::string &message,
-      // unsigned int logLevel) {
-      //   _RCTLogJavaScriptInternal(static_cast<RCTLogLevel>(logLevel),
-      //   [NSString stringWithUTF8String:message.c_str()]);
-      // };
-      // react::bindNativeLogger(runtime, iosLoggingBinder);
+      //TODO rnsLoggingBinder to be updated similar to RCTLog.mm
+      //TODO Update logging formatting of RnsLog to avoid logging filename
+      react::Logger rnsLoggingBinder = [](const std::string &message,unsigned int logLevel) {
+         switch(logLevel) {
+            case 3:RNS_LOG_ERROR("[NativeLogger] " << message.c_str());break;
+            case 2:RNS_LOG_WARN("[NativeLogger] " << message.c_str());break;
+            case 1:RNS_LOG_INFO("[NativeLogger] " << message.c_str());break;
+            case 0:
+            default:
+                   RNS_LOG_TRACE("[NativeLogger] " << message.c_str());
+         }
+      };
+      react::bindNativeLogger(runtime, rnsLoggingBinder);
+
       TurboModuleBinding::install(
           runtime, std::move(jsiTurboModuleManager->GetProvider()));
     };


### PR DESCRIPTION
1. NativeLogger based on RNS logging used by console.js .

Format of Logs when application uses console messages 
console.log("message")  ==> I0724 22:03:41.253280 1826060032 AppLog.h:13] ReactNativeJS: message
console.error("message") ==> E0724 22:03:41.257189 1826060032 AppLog.h:11] ReactNativeJS: message
console.warn("message") ==> W0724 22:03:41.259263 1826060032 AppLog.h:12] ReactNativeJS: message

2. NativePerformanceNow based on skia's SKTime interface