### PR TITLE
RNS Shell minor improvments 

### DIFF
--- a/ReactSkia/core_modules/RSkDeviceInfo.h
+++ b/ReactSkia/core_modules/RSkDeviceInfo.h
@@ -8,8 +8,9 @@
 #include "cxxreact/Instance.h"
 #include "ReactCommon/TurboModule.h"
 #include "core_modules/RSkEventEmitter.h"
-#include "rns_shell/common/Window.h"
 #include "sdk/NotificationCenter.h"
+
+#include "rns_shell/common/Window.h"
 
 namespace facebook {
 namespace react {

--- a/rns_shell/common/Window.h
+++ b/rns_shell/common/Window.h
@@ -29,6 +29,7 @@ class Window {
 public:
     static Window* createNativeWindow(void* platformData);
     static void createEventLoop(Application* app);
+    static Window* getMainWindow() { return mainWindow_; }
     static SkSize getMainWindowSize() {
         if(mainWindow_)
             return mainWindow_->getWindowSize();

--- a/rns_shell/common/WindowContext.h
+++ b/rns_shell/common/WindowContext.h
@@ -50,6 +50,7 @@ public:
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
     virtual bool hasSwapBuffersWithDamage() = 0; // Support for swapping/flipping multiple regions of backbuffer to frontbuffer
     virtual bool hasBufferCopy() = 0; // Support for copying frontbuffer to backbuffer. Required/used only when hasSwapBuffersWithDamage is false
+    virtual int32_t bufferAge() = 0; // Age of current backbuffer
 #endif
 
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT

--- a/rns_shell/common/WindowContext.h
+++ b/rns_shell/common/WindowContext.h
@@ -24,6 +24,13 @@ class SkSurface;
 
 namespace RnsShell {
 
+#if USE(EGL)
+#include <EGL/egl.h>
+typedef EGLNativeWindowType GLNativeWindowType;
+#else
+typedef uint64_t GLNativeWindowType;
+#endif
+
 class WindowContext {
 public:
     WindowContext(const DisplayParams&);

--- a/rns_shell/common/WindowContext.h
+++ b/rns_shell/common/WindowContext.h
@@ -50,7 +50,9 @@ public:
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
     virtual bool hasSwapBuffersWithDamage() = 0; // Support for swapping/flipping multiple regions of backbuffer to frontbuffer
     virtual bool hasBufferCopy() = 0; // Support for copying frontbuffer to backbuffer. Required/used only when hasSwapBuffersWithDamage is false
+#ifdef RNS_SHELL_HAS_GPU_SUPPORT
     virtual int32_t bufferAge() = 0; // Age of current backbuffer
+#endif
 #endif
 
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT

--- a/rns_shell/compositor/Compositor.cpp
+++ b/rns_shell/compositor/Compositor.cpp
@@ -65,8 +65,7 @@ Compositor::~Compositor() {
 
 void Compositor::createWindowContext() {
     RNS_LOG_ASSERT((nativeWindowHandle_), "Invalid Native Window Handle");
-    windowContext_ = WCF::createContextForWindow(reinterpret_cast<GLNativeWindowType>(nativeWindowHandle_),
-                        &PlatformDisplay::sharedDisplayForCompositing(), DisplayParams());
+    windowContext_ = WCF::createContextForWindow(nativeWindowHandle_, &PlatformDisplay::sharedDisplayForCompositing(), DisplayParams());
 
     if (!windowContext_ || !windowContext_->makeContextCurrent())
         return;

--- a/rns_shell/compositor/Compositor.h
+++ b/rns_shell/compositor/Compositor.h
@@ -61,7 +61,7 @@ private:
     SharedLayer rootLayer_;
     std::unique_ptr<WindowContext> windowContext_;
     sk_sp<SkSurface> backBuffer_;
-    uint64_t nativeWindowHandle_;
+    GLNativeWindowType nativeWindowHandle_;
 
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
     bool supportPartialUpdate_;

--- a/rns_shell/platform/graphics/WindowContextFactory.h
+++ b/rns_shell/platform/graphics/WindowContextFactory.h
@@ -18,12 +18,8 @@
 
 #if USE(EGL)
 #include <EGL/eglplatform.h>
-typedef EGLNativeWindowType GLNativeWindowType;
 #elif USE(GLX)
 #include <GL/glx.h>
-typedef uint64_t GLNativeWindowType;
-#else // !USE(EGL)
-typedef uint64_t GLNativeWindowType;
 #endif
 
 // webgpu_cpp.h and X.h don't get along. Include this first, before X11 defines None, Success etc.
@@ -33,6 +29,7 @@ typedef uint64_t GLNativeWindowType;
 
 #include "ReactSkia/utils/RnsLog.h"
 #include "PlatformDisplay.h"
+#include "WindowContext.h"
 #if PLATFORM(X11)
 #include "x11/PlatformDisplayX11.h"
 #endif

--- a/rns_shell/platform/graphics/gl/GLWindowContext.cpp
+++ b/rns_shell/platform/graphics/gl/GLWindowContext.cpp
@@ -93,6 +93,11 @@ bool GLWindowContext::hasSwapBuffersWithDamage() {
 bool GLWindowContext::hasBufferCopy() {
     return this->onHasBufferCopy();
 }
+
+int32_t GLWindowContext::bufferAge() {
+    return this->getBufferAge();
+}
+
 #endif
 
 void GLWindowContext::setDisplayParams(const DisplayParams& params) {

--- a/rns_shell/platform/graphics/gl/GLWindowContext.h
+++ b/rns_shell/platform/graphics/gl/GLWindowContext.h
@@ -37,12 +37,6 @@
 #include "PlatformDisplay.h"
 #include "WindowContext.h"
 
-#if USE(EGL)
-typedef EGLNativeWindowType GLNativeWindowType;
-#else
-typedef uint64_t GLNativeWindowType;
-#endif
-
 namespace RnsShell {
 
 class GLWindowContext : public WindowContext {

--- a/rns_shell/platform/graphics/gl/GLWindowContext.h
+++ b/rns_shell/platform/graphics/gl/GLWindowContext.h
@@ -21,7 +21,7 @@
 #endif // USE(OPENGL_ES)
 
 #if USE(EGL)
-#define EGL_GLEXT_PROTOTYPES 1
+#define EGL_EGLEXT_PROTOTYPES 1
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <EGL/eglplatform.h>
@@ -49,6 +49,7 @@ public:
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
     bool hasSwapBuffersWithDamage() override;
     bool hasBufferCopy() override;
+    int32_t bufferAge() override;
 #endif
 
     void setDisplayParams(const DisplayParams& params) override;
@@ -70,6 +71,7 @@ protected:
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
     virtual bool onHasSwapBuffersWithDamage() = 0;
     virtual bool onHasBufferCopy() = 0;
+    virtual int32_t getBufferAge() = 0;
 #endif
     sk_sp<const GrGLInterface> backendContext_;
     sk_sp<SkSurface>           surface_;

--- a/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.cpp
+++ b/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.cpp
@@ -205,7 +205,7 @@ GLWindowContextEGL::GLWindowContextEGL(GLNativeWindowType window, EGLConfig conf
     this->initializeContext();
 
 #if !defined(GOOGLE_STRIP_LOG) || (GOOGLE_STRIP_LOG <= INFO)
-    EGLint swapBehaviour = 0;
+    EGLint swapBehaviour = EGL_BUFFER_PRESERVED;
     eglQuerySurface(platformDisplay_.eglDisplay(), glSurface_, EGL_SWAP_BEHAVIOR, &swapBehaviour);
     RNS_LOG_DEBUG("GLWindowContextEGL constructed with WH(" << width_ << " x " << height_ << ") SampleCount & StencilBits : [" << sampleCount_ << "," << stencilBits_ <<
                   "], SWAP_BEHAVIOR : " << ((swapBehaviour==EGL_BUFFER_PRESERVED)?"EGL_BUFFER_PRESERVED":"EGL_BUFFER_DESTROYED"));

--- a/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.h
+++ b/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.h
@@ -41,6 +41,7 @@ public:
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
     bool onHasSwapBuffersWithDamage() override;
     bool onHasBufferCopy() override;
+    int32_t getBufferAge() override;
 #endif
 protected:
     sk_sp<const GrGLInterface> onInitializeContext() override;
@@ -65,7 +66,6 @@ private:
 #if USE(WPE_RENDERER)
     void destroyWPETarget();
 #endif
-    int32_t getBufferAge();
     bool makeContextCurrent() override;
     void swapInterval();
 

--- a/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.h
+++ b/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.h
@@ -65,6 +65,7 @@ private:
 #if USE(WPE_RENDERER)
     void destroyWPETarget();
 #endif
+    int32_t getBufferAge();
     bool makeContextCurrent() override;
     void swapInterval();
 

--- a/rns_shell/platform/graphics/gl/egl/GrGLMakeNativeInterfaceEGL.cpp
+++ b/rns_shell/platform/graphics/gl/egl/GrGLMakeNativeInterfaceEGL.cpp
@@ -8,21 +8,144 @@
 
 // Must be added before X11 headrs because Folly uses "Struct None" and X11 has "#define None 0L" which conflicts
 #include "src/gpu/gl/GrGLUtil.h"
+// USE macro is defined here so need to include on before using USE macro
+#include "ReactSkia/utils/RnsUtils.h"
 
 // Define this to get a prototype for eglGetProcAddress on some systems
 #define EGL_EGLEXT_PROTOTYPES 1
+#define GL_GLEXT_PROTOTYPES 1
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
+#if USE(OPENGL_ES)
+#include <GLES2/gl2.h>
+#if defined(GL_ES_VERSION_3_0) && GL_ES_VERSION_3_0
+#include <GLES3/gl3.h>
+#endif
+#else
+#include <GL/gl.h>
+#endif
+
 #include "include/gpu/gl/GrGLAssembleInterface.h"
 #include "include/gpu/gl/GrGLInterface.h"
-
-#include "ReactSkia/utils/RnsUtils.h"
 
 static GrGLFuncPtr egl_get(void* ctx, const char name[]) {
 
     SkASSERT(nullptr == ctx);
     SkASSERT(eglGetCurrentContext());
+
+    // https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_get_all_proc_addresses.txt
+    // eglGetProcAddress() is not guaranteed to support the querying of non-extension EGL functions.
+#define M(X) if (0 == strcmp(#X, name)) { return (GrGLFuncPtr) X; }
+    M(eglGetCurrentDisplay)
+    M(eglQueryString)
+    M(glActiveTexture)
+    M(glAttachShader)
+    M(glBindAttribLocation)
+    M(glBindBuffer)
+    M(glBindFramebuffer)
+    M(glBindRenderbuffer)
+    M(glBindTexture)
+    M(glBlendColor)
+    M(glBlendEquation)
+    M(glBlendFunc)
+    M(glBufferData)
+    M(glBufferSubData)
+    M(glCheckFramebufferStatus)
+    M(glClear)
+    M(glClearColor)
+    M(glClearStencil)
+    M(glColorMask)
+    M(glCompileShader)
+    M(glCompressedTexImage2D)
+    M(glCompressedTexSubImage2D)
+    M(glCopyTexSubImage2D)
+    M(glCreateProgram)
+    M(glCreateShader)
+    M(glCullFace)
+    M(glDeleteBuffers)
+    M(glDeleteFramebuffers)
+    M(glDeleteProgram)
+    M(glDeleteRenderbuffers)
+    M(glDeleteShader)
+    M(glDeleteTextures)
+    M(glDepthMask)
+    M(glDisable)
+    M(glDisableVertexAttribArray)
+    M(glDrawArrays)
+    M(glDrawElements)
+    M(glEnable)
+    M(glEnableVertexAttribArray)
+    M(glFinish)
+    M(glFlush)
+    M(glFramebufferRenderbuffer)
+    M(glFramebufferTexture2D)
+    M(glFrontFace)
+    M(glGenBuffers)
+    M(glGenFramebuffers)
+    M(glGenRenderbuffers)
+    M(glGenTextures)
+    M(glGenerateMipmap)
+    M(glGetBufferParameteriv)
+    M(glGetError)
+    M(glGetFramebufferAttachmentParameteriv)
+    M(glGetIntegerv)
+    M(glGetProgramInfoLog)
+    M(glGetProgramiv)
+    M(glGetRenderbufferParameteriv)
+    M(glGetShaderInfoLog)
+    M(glGetShaderPrecisionFormat)
+    M(glGetShaderiv)
+    M(glGetString)
+    M(glGetUniformLocation)
+    M(glIsTexture)
+    M(glLineWidth)
+    M(glLinkProgram)
+    M(glPixelStorei)
+    M(glReadPixels)
+    M(glRenderbufferStorage)
+    M(glScissor)
+    M(glShaderSource)
+    M(glStencilFunc)
+    M(glStencilFuncSeparate)
+    M(glStencilMask)
+    M(glStencilMaskSeparate)
+    M(glStencilOp)
+    M(glStencilOpSeparate)
+    M(glTexImage2D)
+    M(glTexParameterf)
+    M(glTexParameterfv)
+    M(glTexParameteri)
+    M(glTexParameteriv)
+    M(glTexSubImage2D)
+    M(glUniform1f)
+    M(glUniform1fv)
+    M(glUniform1i)
+    M(glUniform1iv)
+    M(glUniform2f)
+    M(glUniform2fv)
+    M(glUniform2i)
+    M(glUniform2iv)
+    M(glUniform3f)
+    M(glUniform3fv)
+    M(glUniform3i)
+    M(glUniform3iv)
+    M(glUniform4f)
+    M(glUniform4fv)
+    M(glUniform4i)
+    M(glUniform4iv)
+    M(glUniformMatrix2fv)
+    M(glUniformMatrix3fv)
+    M(glUniformMatrix4fv)
+    M(glUseProgram)
+    M(glVertexAttrib1f)
+    M(glVertexAttrib2fv)
+    M(glVertexAttrib3fv)
+    M(glVertexAttrib4fv)
+    M(glVertexAttribPointer)
+    M(glViewport)
+#undef M
+
     return eglGetProcAddress(name);
 }
 

--- a/rns_shell/platform/graphics/gl/glx/GLWindowContextGLX.h
+++ b/rns_shell/platform/graphics/gl/glx/GLWindowContextGLX.h
@@ -31,6 +31,7 @@ public:
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
     bool onHasSwapBuffersWithDamage() override { RNS_LOG_NOT_IMPL; return false; }
     bool onHasBufferCopy() override { RNS_LOG_NOT_IMPL; return false; };
+    int32_t getBufferAge() override { RNS_LOG_NOT_IMPL; return 0; }
 #endif
 protected:
     sk_sp<const GrGLInterface> onInitializeContext() override;


### PR DESCRIPTION
- eglGetProcAddress() is not guaranteed to support the querying of non-extension EGL functions so improved egl_get() function
- Added two internal API getMainWindow() and getBufferAge() to get Apps main window and age of current opengl backbuffer
- Added new interface to get bufferage from compositor.
- Defination of GLNativeWindowType was in multiple headers, Now we will have at only one place(header).
- Fixed typo in EGL_EGLEXT_PROTOTYPES macro
- Added initialization for eglSetDamageRegion if supported by the platform.
- Optimized addDamageRect function.
  - If new dirty rect fully covers any of existing dirtyRect in the vector, then remove them from vector
  - If new dirty rect is inside any of existing dirtyRects, then ignore and return
- Added additional debug logs.