### PR TITLE
Support TextInput Props IN OSK Launch

### DIFF
--- a/ReactSkia/components/RSkComponentTextInput.cpp
+++ b/ReactSkia/components/RSkComponentTextInput.cpp
@@ -10,7 +10,6 @@
 #include "ReactSkia/components/RSkComponent.h"
 #include "ReactSkia/core_modules/RSkSpatialNavigator.h"
 #include "ReactSkia/sdk/RNSKeyCodeMapping.h"
-#include "ReactSkia/sdk/OnScreenKeyBoard.h"
 #include "ReactSkia/views/common/RSkDrawUtils.h"
 #include "ReactSkia/views/common/RSkConversion.h"
 #include "ReactSkia/views/common/RSkSdkConversion.h"
@@ -519,7 +518,10 @@ void RSkComponentTextInput::requestForEditingMode(bool isFlushDisplay){
        drawAndSubmit(isFlushDisplay);
     }
   }
-  if(showSoftInputOnFocus_) OnScreenKeyboard::launch(oskLaunchConfig_);
+  if(showSoftInputOnFocus_){
+    OnScreenKeyboard::launch(oskLaunchConfig_);
+    isOSKActive_=true;
+  }
   RNS_LOG_DEBUG("[requestForEditingMode] END");
 }
 
@@ -546,7 +548,10 @@ void RSkComponentTextInput::resignFromEditingMode(bool isFlushDisplay) {
   if (!caretHidden_) {
     drawAndSubmit(isFlushDisplay);
   }
-  if(showSoftInputOnFocus_) OnScreenKeyboard::exit();
+  if(isOSKActive_){
+    OnScreenKeyboard::exit();
+    isOSKActive_=false;
+  }
   RNS_LOG_DEBUG("[requestForEditingMode] *** END ***");
 }
 

--- a/ReactSkia/components/RSkComponentTextInput.cpp
+++ b/ReactSkia/components/RSkComponentTextInput.cpp
@@ -5,6 +5,8 @@
  * found in the LICENSE file.
  */
 
+#define NEED_OSK_CONVERSION_SUPPORT /* To Enable RSK to OSK sdk value conversion in RSkConversion.h*/
+
 #include "include/core/SkPaint.h"
 #include "ReactSkia/components/RSkComponentTextInput.h"
 #include "ReactSkia/components/RSkComponent.h"
@@ -416,7 +418,7 @@ RnsShell::LayerInvalidateMask  RSkComponentTextInput::updateComponentProps(const
       && ((placeholderString_) != (textInputProps.placeholder))
       &&(!textInputProps.value.has_value())) {
 
-    placeholderString_ = textInputProps.placeholder.c_str();
+    oskLaunchConfig_.placeHolderName=placeholderString_ = textInputProps.placeholder.c_str();
     if(!displayString_.size()) {
       mask |= LayerPaintInvalidate;
     }
@@ -450,6 +452,14 @@ RnsShell::LayerInvalidateMask  RSkComponentTextInput::updateComponentProps(const
     caretHidden_ = true;
   }
   hasToSetFocus_ = forceUpdate && textInputProps.autoFocus ? true :false;
+
+/* Fetch OnSCreenKeyBoard Props*/
+  showSoftInputOnFocus_=textInputProps.traits.showSoftInputOnFocus;
+  oskLaunchConfig_.type=RSkToOSKKeyboardType(textInputProps.traits.keyboardType);
+  oskLaunchConfig_.theme=RSkToOSKKeyboardTheme(textInputProps.traits.keyboardAppearance);
+  oskLaunchConfig_.returnKeyLabel=RSkToOSKReturnKeyType(textInputProps.traits.returnKeyType);
+  oskLaunchConfig_.enablesReturnKeyAutomatically=textInputProps.traits.enablesReturnKeyAutomatically;
+ 
   return (RnsShell::LayerInvalidateMask)mask;
 }
 
@@ -510,16 +520,7 @@ void RSkComponentTextInput::requestForEditingMode(bool isFlushDisplay){
        drawAndSubmit(isFlushDisplay);
     }
   }
-  /*
-     TODO:Launching with default configuration for now.
-          Need to parse & pass properties :
-       1. keyboardType [oskType]
-       2. returnKeyType [returnKeyLabel]
-       3. keyboardAppearance [oskTheme]
-       4. enablesReturnKeyAutomatically [enablesReturnKeyAutomatically]
-       5. placeholder [placeHolderName]
-  */
-  OnScreenKeyboard::launch();
+  if(showSoftInputOnFocus_) OnScreenKeyboard::launch(oskLaunchConfig_);
   RNS_LOG_DEBUG("[requestForEditingMode] END");
 }
 
@@ -546,7 +547,7 @@ void RSkComponentTextInput::resignFromEditingMode(bool isFlushDisplay) {
   if (!caretHidden_) {
     drawAndSubmit(isFlushDisplay);
   }
-  OnScreenKeyboard::exit();
+  if(showSoftInputOnFocus_) OnScreenKeyboard::exit();
   RNS_LOG_DEBUG("[requestForEditingMode] *** END ***");
 }
 

--- a/ReactSkia/components/RSkComponentTextInput.cpp
+++ b/ReactSkia/components/RSkComponentTextInput.cpp
@@ -5,8 +5,6 @@
  * found in the LICENSE file.
  */
 
-#define NEED_OSK_CONVERSION_SUPPORT /* To Enable RSK to OSK sdk value conversion in RSkConversion.h*/
-
 #include "include/core/SkPaint.h"
 #include "ReactSkia/components/RSkComponentTextInput.h"
 #include "ReactSkia/components/RSkComponent.h"
@@ -15,6 +13,7 @@
 #include "ReactSkia/sdk/OnScreenKeyBoard.h"
 #include "ReactSkia/views/common/RSkDrawUtils.h"
 #include "ReactSkia/views/common/RSkConversion.h"
+#include "ReactSkia/views/common/RSkSdkConversion.h"
 #include "rns_shell/compositor/layers/PictureLayer.h"
 
 #include <string.h>
@@ -455,9 +454,9 @@ RnsShell::LayerInvalidateMask  RSkComponentTextInput::updateComponentProps(const
 
 /* Fetch OnSCreenKeyBoard Props*/
   showSoftInputOnFocus_=textInputProps.traits.showSoftInputOnFocus;
-  oskLaunchConfig_.type=RSkToOSKKeyboardType(textInputProps.traits.keyboardType);
-  oskLaunchConfig_.theme=RSkToOSKKeyboardTheme(textInputProps.traits.keyboardAppearance);
-  oskLaunchConfig_.returnKeyLabel=RSkToOSKReturnKeyType(textInputProps.traits.returnKeyType);
+  oskLaunchConfig_.type=RSkToSdkOSKeyboardType(textInputProps.traits.keyboardType);
+  oskLaunchConfig_.theme=RSkToSdkOSKeyboardTheme(textInputProps.traits.keyboardAppearance);
+  oskLaunchConfig_.returnKeyLabel=RSkToSdkOSKReturnKeyType(textInputProps.traits.returnKeyType);
   oskLaunchConfig_.enablesReturnKeyAutomatically=textInputProps.traits.enablesReturnKeyAutomatically;
  
   return (RnsShell::LayerInvalidateMask)mask;

--- a/ReactSkia/components/RSkComponentTextInput.h
+++ b/ReactSkia/components/RSkComponentTextInput.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "modules/skparagraph/include/TextStyle.h"
 #include "react/renderer/components/textinput/TextInputShadowNode.h"
 #include "react/renderer/components/textinput/TextInputEventEmitter.h"
@@ -41,8 +43,8 @@ class RSkComponentTextInput final : public RSkComponent {
   bool isTextInputInFocus_=false;
   bool secureTextEntry_=false;
   bool hasToSetFocus_=false;
-  bool showSoftInputOnFocus_=true;//To decide OnScreen KeyBoard to be used or not
-
+  std::atomic<bool> showSoftInputOnFocus_=true;//To decide OnScreen KeyBoard to be used or not
+  bool isOSKActive_=false; // maintaining KB launch state, to decide need to Exit OSK
   int eventCount_;
   int maxLength_;
   std::string displayString_{}; // Text to be displayed on screen

--- a/ReactSkia/components/RSkComponentTextInput.h
+++ b/ReactSkia/components/RSkComponentTextInput.h
@@ -11,6 +11,7 @@
 #include "react/renderer/components/textinput/TextInputShadowNode.h"
 #include "react/renderer/components/textinput/TextInputEventEmitter.h"
 #include "ReactSkia/components/RSkComponent.h"
+#include "ReactSkia/sdk/OnScreenKeyBoard.h"
 #include "ReactSkia/textlayoutmanager/RSkTextLayoutManager.h"
 
 
@@ -40,6 +41,8 @@ class RSkComponentTextInput final : public RSkComponent {
   bool isTextInputInFocus_=false;
   bool secureTextEntry_=false;
   bool hasToSetFocus_=false;
+  bool showSoftInputOnFocus_=true;//To decide OnScreen KeyBoard to be used or not
+
   int eventCount_;
   int maxLength_;
   std::string displayString_{}; // Text to be displayed on screen
@@ -47,6 +50,7 @@ class RSkComponentTextInput final : public RSkComponent {
   SharedColor placeholderColor_;  // Placeholder Text Color
   SharedColor selectionColor_;
   struct cursor cursor_;
+  rns::sdk::OSKConfig oskLaunchConfig_;
   SkPaint cursorPaint_;
   std::shared_ptr<skia::textlayout::Paragraph> paragraph_;
   void drawAndSubmit(bool isFlushDisplay=true);

--- a/ReactSkia/sdk/OSKConfig.h
+++ b/ReactSkia/sdk/OSKConfig.h
@@ -29,7 +29,7 @@ namespace sdk {
 #define OSK_WINDOW_WIDTH                      1 /*100% of Screen Size*/
 #define OSK_WINDOW_HEIGTH                     1
 
-#define OSK_PLACEHOLDER_NAME_VERTICAL_OFFSET  0.15
+#define OSK_PLACEHOLDER_NAME_VERTICAL_OFFSET  0.18
 #define OSK_PLACEHOLDER_VERTICAL_OFFSET       0.2
 #define OSK_PLACEHOLDER_LENGTH                0.7 /*Total display view will be x% of the screen size*/
 #define OSK_PLACEHOLDER_HEIGHT                50

--- a/ReactSkia/sdk/OSKLayout.h
+++ b/ReactSkia/sdk/OSKLayout.h
@@ -31,6 +31,7 @@ enum partitionID {
 /* KeyBoard Layout for Alpha Numeric KeyBoard */
 
 #define ALPHA_NUMERIC_KB_PARTITION_COUNT   4
+SkPoint alphaNumericKBReturnKeyIndex{2,13};
 KBLayoutKeyPosContainer alphaNumericKBKeyPos;
 KBLayoutSibblingInfoContainer alphaNumericKBKeySiblingInfo;
 KBLayoutKeyInfoContainer alphaNumericKBKeyInfo= {
@@ -83,7 +84,7 @@ KBLayoutKeyInfoContainer alphaNumericKBKeyInfo= {
     {"y",RNS_KEY_y,KEY_TYPE_TEXT,GROUP3},
     {"z",RNS_KEY_z,KEY_TYPE_TEXT,GROUP3},
     {".",RNS_KEY_Period,KEY_TYPE_TEXT,GROUP3},
-    {"done",RNS_KEY_Select,KEY_TYPE_FUNCTION,GROUP4}
+    {"return",RNS_KEY_Select,KEY_TYPE_FUNCTION,GROUP4}
   },
   {
     //row 4
@@ -118,6 +119,7 @@ keyPlacementConfig_t alphaNumericKBGroupConfig[ALPHA_NUMERIC_KB_PARTITION_COUNT]
 KBLayoutSibblingInfoContainer symbolKBKBKeySiblingInfo;
 KBLayoutKeyPosContainer symbolKBKBKeyPos;
 #define SYMBOL_KB_PARTITION_COUNT 3
+SkPoint symbolKBReturnKeyIndex{2,11};
 KBLayoutKeyInfoContainer symbolKBKBKeyInfo={
   {
     {"123ABC",RNS_KEY_UnKnown,KEY_TYPE_TOGGLE,GROUP1},
@@ -165,7 +167,7 @@ KBLayoutKeyInfoContainer symbolKBKBKeyInfo={
     {"-",RNS_KEY_Minus,KEY_TYPE_TEXT,GROUP2},
     {"right", RNS_KEY_Right,KEY_TYPE_FUNCTION,GROUP2},
     {"left", RNS_KEY_Left,KEY_TYPE_FUNCTION,GROUP2},
-    {"done",RNS_KEY_Select,KEY_TYPE_FUNCTION,GROUP3},
+    {"return",RNS_KEY_Select,KEY_TYPE_FUNCTION,GROUP3},
   }
 };
 
@@ -183,6 +185,7 @@ keyPlacementConfig_t symbolKBGroupConfig[SYMBOL_KB_PARTITION_COUNT]={
 KBLayoutSibblingInfoContainer numericKBKeySiblingInfo;
 KBLayoutKeyPosContainer numericKBKeyPos;
 #define NUMERIC_KB_PARTITION_COUNT 1
+SkPoint  numericKBReturnKeyIndex{3,3};
 KBLayoutKeyInfoContainer numericKBKeyKeyInfo={
   {
     //row 1
@@ -210,7 +213,7 @@ KBLayoutKeyInfoContainer numericKBKeyKeyInfo={
     {",",RNS_KEY_Comma,KEY_TYPE_TEXT,GROUP1},
     {"0",RNS_KEY_0,KEY_TYPE_TEXT,GROUP1},
     {".",RNS_KEY_Period,KEY_TYPE_TEXT,GROUP1 },
-    {"done",RNS_KEY_Select,KEY_TYPE_FUNCTION,GROUP1}
+    {"return",RNS_KEY_Select,KEY_TYPE_FUNCTION,GROUP1}
   }
 };
 
@@ -237,7 +240,9 @@ typedef std::map<std::string,UnicharFontConfig_t> FunctionKeymap;
 FunctionKeymap functionKeyMap = {
   {"delete",{0x232B,1}},
   {"space",{0x23B5,2}},
-  {"done",{0x23CE,1.5}},
+  {"return",{0x23CE,1.5}}, // default return key entry: "enter"
+  {"enter",{0x23CE,1.5}},
+  {"search",{0x2315,2.5}},
   {"right",{0x25BA,1}},
   {"left",{0x25c4,1}}
 };

--- a/ReactSkia/sdk/OSKLayout.h
+++ b/ReactSkia/sdk/OSKLayout.h
@@ -31,7 +31,7 @@ enum partitionID {
 /* KeyBoard Layout for Alpha Numeric KeyBoard */
 
 #define ALPHA_NUMERIC_KB_PARTITION_COUNT   4
-SkPoint alphaNumericKBReturnKeyIndex{2,13};
+SkPoint alphaNumericKBReturnKeyIndex{13,2};/*KeyIndex,RowIndex*/
 KBLayoutKeyPosContainer alphaNumericKBKeyPos;
 KBLayoutSibblingInfoContainer alphaNumericKBKeySiblingInfo;
 KBLayoutKeyInfoContainer alphaNumericKBKeyInfo= {
@@ -119,7 +119,7 @@ keyPlacementConfig_t alphaNumericKBGroupConfig[ALPHA_NUMERIC_KB_PARTITION_COUNT]
 KBLayoutSibblingInfoContainer symbolKBKBKeySiblingInfo;
 KBLayoutKeyPosContainer symbolKBKBKeyPos;
 #define SYMBOL_KB_PARTITION_COUNT 3
-SkPoint symbolKBReturnKeyIndex{2,11};
+SkPoint symbolKBReturnKeyIndex{11,2};/*KeyIndex,RowIndex*/
 KBLayoutKeyInfoContainer symbolKBKBKeyInfo={
   {
     {"123ABC",RNS_KEY_UnKnown,KEY_TYPE_TOGGLE,GROUP1},

--- a/ReactSkia/sdk/OnScreenKeyBoard.cpp
+++ b/ReactSkia/sdk/OnScreenKeyBoard.cpp
@@ -249,7 +249,7 @@ inline void OnScreenKeyboard::drawKBKeyFont(SkPoint index,SkColor color,bool onH
     bool needsCanvasRestore{false};
     if(oskLayout_.keyInfo->at(rowIndex).at(keyIndex).keyType == KEY_TYPE_FUNCTION) {
      /*TempFix: Search Icon Presented properly only by "DejaVu Sans Mono/monospace" family. So hardcoding it
-       Enchancement : When more icon needs custom handling, custom options to be specified in functionKeyMap to handle in a genric way
+       NOTE : When more icon needs custom handling, custom options to be specified in functionKeyMap to handle in a genric way
      */
       char* fontFamily=nullptr;
       if(!strcmp(keyName,"return")) {
@@ -277,6 +277,10 @@ inline void OnScreenKeyboard::drawKBKeyFont(SkPoint index,SkColor color,bool onH
           /*Current Search icon used needs a flip to be alligned with rest of the icons*/
           if(!strcmp(keyName,"search")) {
             SkRect bounds;
+            /*NOTE:: TBD-On extending supports for return keys, decision to be taken whether
+                     draw co-ordiantes for any other return keys (other than deafult) to be done
+                     here while drawing or can calculate during LAyout creation and maintained seperately
+            */
             font.measureText(uniChar.c_str(), uniChar.size(), SkTextEncoding::kUTF8, &bounds);
             textX = oskLayout_.keyPos->at(rowIndex).at(keyIndex).highlightTile.x() + ((oskLayout_.keyPos->at(rowIndex).at(keyIndex).highlightTile.width() - bounds.width() )/2);
             textY = oskLayout_.keyPos->at(rowIndex).at(keyIndex).highlightTile.y() + ((oskLayout_.keyPos->at(rowIndex).at(keyIndex).highlightTile.height() + bounds.height()) /2);

--- a/ReactSkia/sdk/OnScreenKeyBoard.cpp
+++ b/ReactSkia/sdk/OnScreenKeyBoard.cpp
@@ -428,12 +428,6 @@ void OnScreenKeyboard::onHWkeyHandler(rnsKey keyValue, rnsKeyAction eventKeyActi
               hlCandidate.set(keyIndex,rowIndex);
               keyFound=true;
               OSKkeyValue =keyValue;
-              /* Enable Reurn Key on Valid Key EVent if disabled*/
-              if(autoActivateReturnKey) {
-                autoActivateReturnKey=false;
-                drawKBKeyFont(oskLayout_.returnKeyIndex,fontColor_);
-                drawCallPendingToRender=true;
-              }
               break;
             }
           }
@@ -445,6 +439,12 @@ void OnScreenKeyboard::onHWkeyHandler(rnsKey keyValue, rnsKeyAction eventKeyActi
   if((lastFocussIndex_ != hlCandidate)) {
     drawHighLightOnKey(hlCandidate);
     currentFocussIndex_=hlCandidate;
+    drawCallPendingToRender=true;
+  }
+  /* Enable Reurn Key on Valid Key EVent if disabled*/
+  if((OSKkeyValue != RNS_KEY_UnKnown) && autoActivateReturnKey) {
+    autoActivateReturnKey=false;
+    drawKBKeyFont(oskLayout_.returnKeyIndex,fontColor_);
     drawCallPendingToRender=true;
   }
   if( drawCallPendingToRender && (oskState_== OSK_STATE_ACTIVE)) commitDrawCall();

--- a/ReactSkia/sdk/OnScreenKeyBoard.cpp
+++ b/ReactSkia/sdk/OnScreenKeyBoard.cpp
@@ -55,7 +55,15 @@ void OnScreenKeyboard::exit() {
   }
   std::scoped_lock lock(oskLaunchExitCtrlMutex);
   oskHandle.closeWindow();
+
+/*Resetting old values & States*/
   oskHandle.oskState_=OSK_STATE_INACTIVE;
+  oskHandle.autoActivateReturnKey=false;
+
+  oskHandle.displayString_.clear();
+  oskHandle.lastDisplayedString_.clear();
+  oskHandle.lastFocussIndex_.set(0,0);
+  oskHandle.currentFocussIndex_.set(0,0);
 }
 
 void  OnScreenKeyboard::updatePlaceHolderString(std::string PHdisplayString) {
@@ -85,6 +93,9 @@ void OnScreenKeyboard::launchOSKWindow(OSKConfig oskConfig) {
   if(oskConfig_.type == OSK_ALPHA_NUMERIC_KB)
     oskLayout_.kbLayoutType = ALPHA_LOWERCASE_LAYOUT;
 
+  if(oskConfig_.enablesReturnKeyAutomatically)
+    autoActivateReturnKey=true;
+
   unsigned int XscaleFactor = screenSize_.width()/baseScreenSize.width();
   unsigned int YscaleFactor =screenSize_.height()/baseScreenSize.height();
   oskLayout_.textFontSize= OSK_FONT_SIZE *XscaleFactor;
@@ -106,11 +117,11 @@ if(oskState_!= OSK_STATE_ACTIVE) return;
 
 /*2. Draw PlaceHolder*/
   SkPaint paint;
-  if(oskConfig_.placeHolderName) {
+  if(!oskConfig_.placeHolderName.empty()) {
     SkFont font;
     paint.setColor(fontColor_);
     font.setSize(OSK_FONT_SIZE);
-    windowDelegatorCanvas->drawSimpleText(oskConfig_.placeHolderName,strlen(oskConfig_.placeHolderName), SkTextEncoding::kUTF8,
+    windowDelegatorCanvas->drawSimpleText(oskConfig_.placeHolderName.c_str(),oskConfig_.placeHolderName.size(), SkTextEncoding::kUTF8,
                                oskLayout_.horizontalStartOffset,
                                screenSize_.height()*OSK_PLACEHOLDER_NAME_VERTICAL_OFFSET,
                                font, paint);
@@ -235,25 +246,60 @@ inline void OnScreenKeyboard::drawKBKeyFont(SkPoint index,SkColor color,bool onH
       textY=oskLayout_.keyPos->at(rowIndex).at(keyIndex).textXY.y();
     }
 
+    bool needsCanvasRestore{false};
     if(oskLayout_.keyInfo->at(rowIndex).at(keyIndex).keyType == KEY_TYPE_FUNCTION) {
-        FunctionKeymap :: iterator keyFunction =functionKeyMap.find(keyName);
-        keyName=(char *)DRAW_FONT_FAILURE_INDICATOR;
-        if(keyFunction != functionKeyMap.end()) {
-            UnicharFontConfig_t uniCharConfig = keyFunction->second;
-            sk_sp<SkFontMgr> mgr(SkFontMgr::RefDefault());
-            sk_sp<SkTypeface> typeface(mgr->matchFamilyStyleCharacter(nullptr, SkFontStyle(), nullptr, 0, uniCharConfig.unicharValue));
-            if (typeface) {
-                uniChar.appendUnichar(uniCharConfig.unicharValue);
-                font.setTypeface(typeface);
-                if(onHLTile)
-                    font.setSize(oskLayout_.textHLFontSize* uniCharConfig.fontScaleFactor);
-                else
-                  font.setSize(oskLayout_.textFontSize* uniCharConfig.fontScaleFactor);
-                keyName=(char *)uniChar.c_str();
-            }
-        }
+     /*TempFix: Search Icon Presented properly only by "DejaVu Sans Mono/monospace" family. So hardcoding it
+       Enchancement : When more icon needs custom handling, custom options to be specified in functionKeyMap to handle in a genric way
+     */
+      char* fontFamily=nullptr;
+      if(!strcmp(keyName,"return")) {
+        /* If autoActivateReturnKey is set. Return key to be presented in disabled/In-Active look until TI was empty.*/
+        if(autoActivateReturnKey && displayString_.empty())
+          textPaint.setColor((oskConfig_.theme == OSK_LIGHT_THEME) ? OSK_LIGHT_THEME_INACTIVE_FONT_COLOR: OSK_DARK_THEME_INACTIVE_FONT_COLOR);
+          if(oskConfig_.returnKeyLabel == OSK_RETURN_KEY_SEARCH) {
+            keyName=(char*)"search";
+            fontFamily =(char *)"DejaVu Sans Mono";
+        } else keyName=(char*)"enter";
+      }
+      FunctionKeymap :: iterator keyFunction =functionKeyMap.find(keyName);
+      if(keyFunction != functionKeyMap.end()) {
+        UnicharFontConfig_t uniCharConfig = keyFunction->second;
+        sk_sp<SkFontMgr> mgr(SkFontMgr::RefDefault());
+        sk_sp<SkTypeface> typeface(mgr->matchFamilyStyleCharacter(fontFamily, SkFontStyle(), nullptr, 0, uniCharConfig.unicharValue));
+
+        if (typeface) {
+          uniChar.appendUnichar(uniCharConfig.unicharValue);
+          font.setTypeface(typeface);
+          if(onHLTile)
+            font.setSize(oskLayout_.textHLFontSize* uniCharConfig.fontScaleFactor);
+          else
+            font.setSize(oskLayout_.textFontSize* uniCharConfig.fontScaleFactor);
+          /*Current Search icon used needs a flip to be alligned with rest of the icons*/
+          if(!strcmp(keyName,"search")) {
+            SkRect bounds;
+            font.measureText(uniChar.c_str(), uniChar.size(), SkTextEncoding::kUTF8, &bounds);
+            textX = oskLayout_.keyPos->at(rowIndex).at(keyIndex).highlightTile.x() + ((oskLayout_.keyPos->at(rowIndex).at(keyIndex).highlightTile.width() - bounds.width() )/2);
+            textY = oskLayout_.keyPos->at(rowIndex).at(keyIndex).highlightTile.y() + ((oskLayout_.keyPos->at(rowIndex).at(keyIndex).highlightTile.height() + bounds.height()) /2);
+            textX-=5;textY+=5;// For allignment
+            windowDelegatorCanvas->save();
+            SkMatrix transformMatrix;
+            //to Flip on x-axis - anchor @ center
+            transformMatrix.preRotate(270,textX+(bounds.width()/2),textY-(bounds.height()/2));
+            transformMatrix.postTranslate(bounds.width()/2,0);
+            windowDelegatorCanvas->concat(transformMatrix);
+            needsCanvasRestore=true;
+          }
+ #ifdef DISPLAY_FONT_FAMILY_INFO
+              SkString familyName;
+              typeface->getFamilyName(&familyName);
+              RNS_LOG_INFO(" Font Family Name :"<<familyName.c_str() <<" Key Name : "<<keyName);
+#endif/*DISPLAY_FONT_FAMILY_INFO*/
+          keyName=(char *)uniChar.c_str();
+        } else  keyName=(char *)DRAW_FONT_FAILURE_INDICATOR;
+      } else keyName=(char *)DRAW_FONT_FAILURE_INDICATOR;
     }
     windowDelegatorCanvas->drawSimpleText(keyName, strlen(keyName), SkTextEncoding::kUTF8,textX,textY,font, textPaint);
+    if(needsCanvasRestore) windowDelegatorCanvas->restore();
 #ifdef SHOW_FONT_PLACING_ON_HLTILE
     SkRect bounds;
     textPaint.setColor(SK_ColorRED);
@@ -287,7 +333,7 @@ inline void OnScreenKeyboard::drawKBKeyFont(SkPoint index,SkColor color,bool onH
     textPaint.setColor(SK_ColorMAGENTA);
     windowDelegatorCanvas->drawLine(bounds.fLeft,bounds.fTop+(bounds.height()/2),bounds.fRight,bounds.fTop+(bounds.height()/2),textPaint);
     windowDelegatorCanvas->drawLine(bounds.fLeft+(bounds.width()/2),bounds.fTop,bounds.fLeft+(bounds.width()/2),bounds.fBottom,textPaint);
-  #endif/*SHOW_FONT_PLACING_ON_HLTILE*/
+#endif/*SHOW_FONT_PLACING_ON_HLTILE*/
   }
 }
 
@@ -299,12 +345,12 @@ void OnScreenKeyboard ::drawHighLightOnKey(SkPoint index) {
   unsigned int rowIndex=index.y(),keyIndex=index.x();
   unsigned int lastRowIndex=lastFocussIndex_.y(),lastKeyIndex=lastFocussIndex_.x();
 
-   RNS_PROFILE_START(HighlightOSKKey)
-   //reset last focussed item
-   paintObj.setColor(bgColor_);
-   paintObj.setAntiAlias(true);
-   windowDelegatorCanvas->drawRect(oskLayout_.keyPos->at(lastRowIndex).at(lastKeyIndex).highlightTile,paintObj);
-   drawKBKeyFont({lastKeyIndex,lastRowIndex},fontColor_);
+  RNS_PROFILE_START(HighlightOSKKey)
+  //reset last focussed item
+  paintObj.setColor(bgColor_);
+  paintObj.setAntiAlias(true);
+  windowDelegatorCanvas->drawRect(oskLayout_.keyPos->at(lastRowIndex).at(lastKeyIndex).highlightTile,paintObj);
+  drawKBKeyFont({lastKeyIndex,lastRowIndex},fontColor_);
 
   //Hight current focussed item
   paintObj.setColor(OSK_HIGHLIGHT_BACKGROUND_COLOR);
@@ -322,11 +368,25 @@ void OnScreenKeyboard::onHWkeyHandler(rnsKey keyValue, rnsKeyAction eventKeyActi
   unsigned int rowIndex=currentFocussIndex_.y(),keyIndex=currentFocussIndex_.x();
   RNS_LOG_DEBUG("KEY RECEIVED : "<<RNSKeyMap[keyValue]);
   switch( keyValue ) {
-  /*Case 1: handle Enter/selection key*/
+/* Case  1: Process Navigation Keys*/
+    case RNS_KEY_Right:
+      hlCandidate= oskLayout_.siblingInfo->at(rowIndex).at(keyIndex).siblingRight;
+    break;
+    case RNS_KEY_Left:
+      hlCandidate= oskLayout_.siblingInfo->at(rowIndex).at(keyIndex).siblingLeft;
+    break;
+    case RNS_KEY_Up:
+      hlCandidate= oskLayout_.siblingInfo->at(rowIndex).at(keyIndex).siblingUp;
+    break;
+    case RNS_KEY_Down:
+      hlCandidate= oskLayout_.siblingInfo->at(rowIndex).at(keyIndex).siblingDown;
+    break;
+/*Case 2: handle Enter/selection key*/
     case RNS_KEY_Select:
     {
+      bool proceedToKeyEmit=false;
       if(oskLayout_.keyInfo->at(rowIndex).at(keyIndex).keyValue == RNS_KEY_Select) {
-        exit();
+        proceedToKeyEmit=true; /* If selection on select/return Key needs to be emitted to client*/
       } else if (oskLayout_.keyInfo->at(rowIndex).at(keyIndex).keyType == KEY_TYPE_TOGGLE){
         ToggleKeyMap :: iterator keyFunction =toggleKeyMap.find(oskLayout_.keyInfo->at(rowIndex).at(keyIndex).keyName);
         if((keyFunction != toggleKeyMap.end()) && (keyFunction->second != oskLayout_.kbLayoutType)) {
@@ -342,27 +402,15 @@ void OnScreenKeyboard::onHWkeyHandler(rnsKey keyValue, rnsKeyAction eventKeyActi
           OSKkeyValue = static_cast<rnsKey>(OSKkeyValue-26);
         }
       }
+      if(!proceedToKeyEmit)break;
     }
-    break;
-/* Case  2: Process Navigation Keys*/
-    case RNS_KEY_Right:
-      hlCandidate= oskLayout_.siblingInfo->at(rowIndex).at(keyIndex).siblingRight;
-    break;
-    case RNS_KEY_Left:
-      hlCandidate= oskLayout_.siblingInfo->at(rowIndex).at(keyIndex).siblingLeft;
-    break;
-    case RNS_KEY_Up:
-      hlCandidate= oskLayout_.siblingInfo->at(rowIndex).at(keyIndex).siblingUp;
-    break;
-    case RNS_KEY_Down:
-      hlCandidate= oskLayout_.siblingInfo->at(rowIndex).at(keyIndex).siblingDown;
-    break;
-    /*Case 3: Emit back other known keys*/
+/*Case 3: Emit back other known keys*/
     default:
     {
       bool keyFound=false;
       /*Process only KB keys*/
-      if((keyValue < RNS_KEY_UnKnown ) && (keyValue >= RNS_KEY_1)) {
+      if(( keyValue == RNS_KEY_Select) ||
+         ((keyValue < RNS_KEY_UnKnown ) && (keyValue >= RNS_KEY_1))) {
         rnsKey layoutKeyValue{RNS_KEY_UnKnown};
         for (unsigned int rowIndex=0; (rowIndex < oskLayout_.keyInfo->size()) && (!keyFound);rowIndex++) {
           for (unsigned int keyIndex=0; keyIndex<oskLayout_.keyInfo->at(rowIndex).size();keyIndex++) {
@@ -370,12 +418,18 @@ void OnScreenKeyboard::onHWkeyHandler(rnsKey keyValue, rnsKeyAction eventKeyActi
             if(( oskLayout_.keyInfo->at(rowIndex).at(keyIndex).keyType == KEY_TYPE_TEXT ) &&
                (oskLayout_.kbLayoutType == ALPHA_UPPERCASE_LAYOUT) &&
                (isalpha(*oskLayout_.keyInfo->at(rowIndex).at(keyIndex).keyName))) {
-                   layoutKeyValue = static_cast<rnsKey>(layoutKeyValue-26);
+                  layoutKeyValue = static_cast<rnsKey>(layoutKeyValue-26);
             }
             if(layoutKeyValue == keyValue) {
               hlCandidate.set(keyIndex,rowIndex);
               keyFound=true;
               OSKkeyValue =keyValue;
+              /* Enable Reurn Key on Valid Key EVent if disabled*/
+              if(autoActivateReturnKey) {
+                autoActivateReturnKey=false;
+                drawKBKeyFont(oskLayout_.returnKeyIndex,fontColor_);
+                drawCallPendingToRender=true;
+              }
               break;
             }
           }
@@ -403,6 +457,7 @@ void OnScreenKeyboard::createOSKLayout(OSKTypes oskType) {
     oskLayout_.keyPos=&numericKBKeyPos;
     oskLayout_.siblingInfo=&numericKBKeySiblingInfo;
     oskLayout_.kbGroupConfig=numericKBGroupConfig;
+    oskLayout_.returnKeyIndex=numericKBReturnKeyIndex;
   } else {
     if(oskLayout_.kbLayoutType == SYMBOL_LAYOUT) {
       RNS_LOG_DEBUG("DRAW call for AlphaNumeric-symbol KB");
@@ -410,12 +465,14 @@ void OnScreenKeyboard::createOSKLayout(OSKTypes oskType) {
       oskLayout_.keyPos=&symbolKBKBKeyPos;
       oskLayout_.siblingInfo=&symbolKBKBKeySiblingInfo;
       oskLayout_.kbGroupConfig=symbolKBGroupConfig;
+      oskLayout_.returnKeyIndex=symbolKBReturnKeyIndex;
     } else {
       RNS_LOG_DEBUG("DRAW call for AlphaNumeric KB : "<<((oskLayout_.kbLayoutType == ALPHA_UPPERCASE_LAYOUT)? "UpperCase" : "LowerCase"));
       oskLayout_.keyInfo=&alphaNumericKBKeyInfo;
       oskLayout_.keyPos=&alphaNumericKBKeyPos;
       oskLayout_.siblingInfo=&alphaNumericKBKeySiblingInfo;
       oskLayout_.kbGroupConfig=alphaNumericKBGroupConfig;
+      oskLayout_.returnKeyIndex=alphaNumericKBReturnKeyIndex;
     }
   }
 

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -31,6 +31,12 @@ enum OSKThemes {
   OSK_DARK_THEME,
   OSK_LIGHT_THEME
 };
+// OnScreenKeyBoard supported Return Key Types
+enum OSKReturnKeyType {
+  OSK_RETURN_KEY_DEFAULT,
+  OSK_RETURN_KEY_SEARCH,
+  OSK_RETURN_KEY_SUPPORT_END,
+};
 // OnScreenKeyBoard Error Codes
 enum OSKErrorCode {
   OSK_LAUNCH_SUCCESS=0,
@@ -41,12 +47,12 @@ enum OSKErrorCode {
 struct OSKConfig {
   OSKTypes        type;
   OSKThemes       theme;
-  const char *    placeHolderName;
-  const char *    returnKeyLabel;
+  OSKReturnKeyType    returnKeyLabel;
+  std::string     placeHolderName;
   bool      enablesReturnKeyAutomatically;
 };
 // Default OSK Configuration to be used, in case client doesn't have any preference
-static OSKConfig defaultOSKConfig={ OSK_ALPHA_NUMERIC_KB, OSK_DARK_THEME, nullptr, "done", false };
+static OSKConfig defaultOSKConfig={ OSK_ALPHA_NUMERIC_KB, OSK_DARK_THEME, OSK_RETURN_KEY_DEFAULT,"", false };
 
 //KeyBoard Layout Type
 enum KBLayoutType {
@@ -117,6 +123,7 @@ class OnScreenKeyboard : public WindowDelegator{
       unsigned int      textHLFontSize;
       unsigned int      horizontalStartOffset;
       SkPoint           defaultFocussIndex;
+      SkPoint           returnKeyIndex;
     };
 
     OnScreenKeyboard(){};
@@ -149,6 +156,7 @@ class OnScreenKeyboard : public WindowDelegator{
     std::string   displayString_{}; // Text to be displayed on screen
     std::string   lastDisplayedString_{};
     OSKState      oskState_{OSK_STATE_INACTIVE};
+    bool          autoActivateReturnKey{false};
 };
 
 }// namespace sdk

--- a/ReactSkia/views/common/RSkConversion.h
+++ b/ReactSkia/views/common/RSkConversion.h
@@ -53,37 +53,5 @@ inline facebook::react::Size RCTSizeFromSkSize(const SkSize &size) {
   return {size.width(), size.height()};
 }
 inline bool isOpaque(float opacity) {
-  return (opacity == MAX_8BIT) ? true:false;
+return (opacity == MAX_8BIT) ? true:false;
 }
-
-#ifdef NEED_OSK_CONVERSION_SUPPORT
-
-inline rns::sdk::OSKTypes RSkToOSKKeyboardType(facebook::react::KeyboardType keyBoardType) {
-  switch(keyBoardType) {
-    case facebook::react::KeyboardType::Numeric:
-      return rns::sdk::OSKTypes::OSK_NUMERIC_KB;
-    default:
-      return rns::sdk::OSKTypes::OSK_ALPHA_NUMERIC_KB;
-  }
-}
-
-inline rns::sdk::OSKThemes RSkToOSKKeyboardTheme(facebook::react::KeyboardAppearance keyBoardTheme) {
-  switch(keyBoardTheme) {
-    case facebook::react::KeyboardAppearance::Light:
-      return rns::sdk::OSKThemes::OSK_LIGHT_THEME;
-    default:
-      return rns::sdk::OSKThemes::OSK_DARK_THEME;
-  }
-}
-
-inline rns::sdk::OSKReturnKeyType RSkToOSKReturnKeyType(facebook::react::ReturnKeyType returnKeyType) {
-  switch(returnKeyType) {
-    case facebook::react::ReturnKeyType::Search:
-      return rns::sdk::OSKReturnKeyType::OSK_RETURN_KEY_SEARCH;
-    default:
-      return rns::sdk::OSKReturnKeyType::OSK_RETURN_KEY_DEFAULT;
-  }
-}
-
-#endif /*NEED_OSK_CONVERSION_SUPPORT*/
-

--- a/ReactSkia/views/common/RSkConversion.h
+++ b/ReactSkia/views/common/RSkConversion.h
@@ -53,5 +53,37 @@ inline facebook::react::Size RCTSizeFromSkSize(const SkSize &size) {
   return {size.width(), size.height()};
 }
 inline bool isOpaque(float opacity) {
-return (opacity == MAX_8BIT) ? true:false;
+  return (opacity == MAX_8BIT) ? true:false;
 }
+
+#ifdef NEED_OSK_CONVERSION_SUPPORT
+
+inline rns::sdk::OSKTypes RSkToOSKKeyboardType(facebook::react::KeyboardType keyBoardType) {
+  switch(keyBoardType) {
+    case facebook::react::KeyboardType::Numeric:
+      return rns::sdk::OSKTypes::OSK_NUMERIC_KB;
+    default:
+      return rns::sdk::OSKTypes::OSK_ALPHA_NUMERIC_KB;
+  }
+}
+
+inline rns::sdk::OSKThemes RSkToOSKKeyboardTheme(facebook::react::KeyboardAppearance keyBoardTheme) {
+  switch(keyBoardTheme) {
+    case facebook::react::KeyboardAppearance::Light:
+      return rns::sdk::OSKThemes::OSK_LIGHT_THEME;
+    default:
+      return rns::sdk::OSKThemes::OSK_DARK_THEME;
+  }
+}
+
+inline rns::sdk::OSKReturnKeyType RSkToOSKReturnKeyType(facebook::react::ReturnKeyType returnKeyType) {
+  switch(returnKeyType) {
+    case facebook::react::ReturnKeyType::Search:
+      return rns::sdk::OSKReturnKeyType::OSK_RETURN_KEY_SEARCH;
+    default:
+      return rns::sdk::OSKReturnKeyType::OSK_RETURN_KEY_DEFAULT;
+  }
+}
+
+#endif /*NEED_OSK_CONVERSION_SUPPORT*/
+

--- a/ReactSkia/views/common/RSkSdkConversion.h
+++ b/ReactSkia/views/common/RSkSdkConversion.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+namespace facebook {
+namespace react {
+
+using namespace rns::sdk;
+
+inline OSKTypes RSkToSdkOSKeyboardType(KeyboardType keyBoardType) {
+  switch(keyBoardType) {
+    case KeyboardType::Numeric:
+      return OSKTypes::OSK_NUMERIC_KB;
+    default:
+      return OSKTypes::OSK_ALPHA_NUMERIC_KB;
+  }
+}
+
+inline OSKThemes RSkToSdkOSKeyboardTheme(KeyboardAppearance keyBoardTheme) {
+  switch(keyBoardTheme) {
+    case KeyboardAppearance::Light:
+      return OSKThemes::OSK_LIGHT_THEME;
+    default:
+      return OSKThemes::OSK_DARK_THEME;
+  }
+}
+
+inline OSKReturnKeyType RSkToSdkOSKReturnKeyType(ReturnKeyType returnKeyType) {
+  switch(returnKeyType) {
+    case ReturnKeyType::Search:
+      return OSKReturnKeyType::OSK_RETURN_KEY_SEARCH;
+    default:
+      return OSKReturnKeyType::OSK_RETURN_KEY_DEFAULT;
+  }
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native-skia/components/textinput/TextInput-OSKProps.js
+++ b/packages/react-native-skia/components/textinput/TextInput-OSKProps.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const React = require('react');
+
+const {
+  StyleSheet,
+  View,
+  Text,
+  TextInput,
+  AppRegistry
+} = require('react-native');
+
+
+const SimpleViewApp = React.Node = () => {
+
+   let defaultReturnKey='none';
+   let defaultKBType='numeric';
+   let defaultKBTheme='light';
+   let needOSK=true;
+   let autoEnableReturnKey=true;
+   let value;
+
+   const [KeyBoardType, onKeyBoardType] = React.useState(defaultKBType);
+   const [KeyBoardAppearence, onKeyBoardAppearence] = React.useState(defaultKBTheme);
+   const [returnKeyType, onreturnKeyType] = React.useState(defaultReturnKey);
+   const [showSoftInputOnFocus, onshowSoftInputOnFocus] = React.useState(needOSK);
+   const [enablesReturnKeyAutomatically, onenablesReturnKeyAutomatically] = React.useState(autoEnableReturnKey);
+
+    const TextInputOSKProps = () => {
+      let launchConfig = "KBTYPE:" + KeyBoardType + " KBTheme : "+KeyBoardAppearence+" ReturnKEyType: "+returnKeyType+" enablesReturnKeyAutomatically : " + enablesReturnKeyAutomatically;
+      return(
+          <View style={styles.Outtercontainer}>
+          <Text style={styles.baseText}>OSK Properties</Text>
+          <View style={styles.container}>
+          <Text style={styles.text}>KeyBoardAppearence: 1. numeric 2. url 3. default</Text>
+          <TextInput showSoftInputOnFocus={false}
+            onSubmitEditing={(e) => {
+             value = (e.nativeEvent.text != "")  ? e.nativeEvent.text : defaultKBType
+             onKeyBoardType(value)}}
+            style={styles.TextInput}/>
+          </View>
+          <View style={styles.container}>
+          <Text style={styles.text}>KeyBoardAppearence: 1. light 2.dark 3. default</Text>
+          <TextInput  showSoftInputOnFocus={false}
+            onSubmitEditing={(e) => {
+              value = (e.nativeEvent.text != "")  ? e.nativeEvent.text : defaultKBTheme
+              onKeyBoardAppearence(value)}}
+            style={styles.TextInput}/>
+          </View>
+          <View style={styles.container}>
+          <Text style={styles.text}>returnKeyType: 1. search 2. done 3. none</Text>
+          <TextInput showSoftInputOnFocus={false}
+            onSubmitEditing={(e) => {
+              value = (e.nativeEvent.text != "") ? e.nativeEvent.text : defaultReturnKey
+              onreturnKeyType(value)}}
+            style={styles.TextInput}/>
+          </View>
+          <View style={styles.container}>
+          <Text style={styles.text}>showSoftInputOnFocus: 1. true 2. false </Text>
+          <TextInput  showSoftInputOnFocus={false}
+             onSubmitEditing={(e) => {
+               value=needOSK;
+               if(e.nativeEvent.text == "false") value=false;
+               if(e.nativeEvent.text == "true") value=true;
+               onshowSoftInputOnFocus(value)}}
+            style={styles.TextInput}/>
+          </View>
+          <View style={styles.container}>
+          <Text style={styles.text}>enablesReturnKeyAutomatically: 1. true 2. false</Text>
+          <TextInput  showSoftInputOnFocus={false}
+            onSubmitEditing={(e) => {
+              value=autoEnableReturnKey;
+              if(e.nativeEvent.text == "false") value=false;
+              if(e.nativeEvent.text == "true") value=true;
+               onenablesReturnKeyAutomatically(value)}}
+            style={styles.TextInput}/>
+          </View>
+          <TextInput 
+            value="Launch OSK"
+            placeholder={launchConfig}
+            keyboardType={KeyBoardType}
+            enablesReturnKeyAutomatically={enablesReturnKeyAutomatically}
+            returnKeyType={returnKeyType}
+            showSoftInputOnFocus={showSoftInputOnFocus}
+            keyboardAppearance={KeyBoardAppearence}
+            textAlign='center'
+            onSubmitEditing={console.log("KeyBoardType", KeyBoardType ,"enablesReturnKeyAutomatically", enablesReturnKeyAutomatically,"returnKeyType", returnKeyType,"showSoftInputOnFocus",showSoftInputOnFocus,"KeyBoardAppearence",KeyBoardAppearence,"launchConfig",launchConfig )}
+            style={styles.input}
+            />
+          </View>
+      )
+    }
+
+  return (
+    TextInputOSKProps()
+  );
+}
+
+const styles = StyleSheet.create({
+  TextInput:{
+    margin:10,
+    backgroundColor:'#61dafb',
+    width:150,
+    height:50,
+    textAlign: "center",
+  },
+  container: {
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    backgroundColor: '#eaeaea',
+    padding: 10,
+    margin: 10,
+    width:700,
+    height:200,
+    borderRadius: 6,
+    borderWidth: 4,
+  },
+  Outtercontainer: {
+    flex: 1,
+    justifyContent: "space-between",
+    backgroundColor: "darkseagreen",
+    padding: 20,
+    margin: 10,
+    width:800,
+    height:600,
+    borderRadius: 6,
+    borderWidth: 4,
+    alignItems:"center"
+  },
+
+  input: {
+  margin: 10,
+  borderWidth: 4,
+  width:150,
+  height:50,
+  backgroundColor: '#eaeaea',
+  },
+  text:{ 
+    fontSize: 15,
+  },
+  baseText: {
+    fontFamily: "Cochin",
+    fontSize: 30,
+    ontWeight: "bold",
+  }
+});
+
+export default SimpleViewApp;
+AppRegistry.registerComponent('SimpleViewApp', () => SimpleViewApp);


### PR DESCRIPTION
**Features Supported/Props**

1. OSK Theme -Default, Light, Dark
2. OSK Type-Default, Numeric [Default : Alpha Numeric KeyBoard ]
3. EnableReturnKey
4. ReturnKeyLabel - search/done [default : done]
5. showSoftInputOnFocus

Note:-
Handled below custom handling for Search icon . 

- 270 deg rotation [ needed to align the icons orientation with others]
- Hardcoded Font Family [ display icon properly with a particular font family]

If more icons needs similar fashion of custom handling, it can be added as part unichar config structure and handle it in generic way. As it is only for one icon Handled as a specific fix, in a view to avoid overhead on other icon w.r.t maintaining dummy data & conditional processing