### PR TITLE
Minor bug fixes in ScrollLayer for handling dynamic updates

### DIFF
--- a/packages/react-native-skia/components/scrollview/ScrollView-Demo.js
+++ b/packages/react-native-skia/components/scrollview/ScrollView-Demo.js
@@ -30,6 +30,7 @@ const SimpleViewApp = React.Node = () => {
   let [tiColor,setTiColor] = React.useState("darkgrey");
   let [scrollConfigs,setScrollConfigs] = React.useState(
     {
+      "showSV"          : false,
       "childItemType" : "View",
       "childItemNum" : 20,
       "_borderWidth" : 0,
@@ -121,6 +122,7 @@ const SimpleViewApp = React.Node = () => {
     }
     else if (configType == "frameWidth") updatedConfig={"_frameWidth" : configValue};
     else if (configType == "frameHeight") updatedConfig={"_frameHeight" : configValue};
+    else if (configType == "showSV") updatedConfig={"showSV" : !scrollConfigs["showSV"]};
 
     setScrollConfigs(scrollConfigs => ({...scrollConfigs,...updatedConfig}));
   }
@@ -155,10 +157,9 @@ const SimpleViewApp = React.Node = () => {
     setScrollEventData(scrollEventData => ({...scrollEventData,...updatedEvent}));
   }
 
-  const mainView = () => {
-    return(
-      <View style={{flex:1,width:windowSize.width,height:windowSize.height,backgroundColor:'darkslategray'}}>
-        <ScrollView ref={scrollViewRef}
+  const scrollView = () => {
+     if(scrollConfigs["showSV"]) {
+        return (<ScrollView ref={scrollViewRef}
               style={[styles.scrollView,{borderWidth:scrollConfigs["_borderWidth"],width:scrollConfigs["_frameWidth"],height:scrollConfigs["_frameHeight"]}]}
               scrollEnabled={scrollProps["_scrollEnabled"]}
               horizontal={scrollProps["_horizontal"]}
@@ -172,14 +173,22 @@ const SimpleViewApp = React.Node = () => {
               scrollIndicatorInsets={scrollProps["_scrollIndicatorInsets"]}
               onScroll={(e) => setScrollEventDetails("onScrollEvent",JSON.stringify(e.nativeEvent))}
               onContentSizeChange={(width,height) => setScrollEventDetails("onContentSizeChange","width:"+width+",height:"+height)} >
-
             {items}
         </ScrollView>
+        );
+     }
+  }
 
+  const mainView = () => {
+    return(
+      <View style={{flex:1,width:windowSize.width,height:windowSize.height,backgroundColor:'darkslategray'}}>
+        {scrollView()}
         <View style={{flexDirection:'column'}}>
           <Text style={[styles.controlButtonText,{textDecorationLine:'underline',fontWeight:'bold',color:'darkorange',marginTop:30}]}>{'CONFIGURATIONS'}</Text>
-
           <View style={{flexDirection:'row',flexWrap:'wrap'}}>
+            <TouchableHighlight underlayColor='darkseagreen' style={styles.controlButton} onPress={() => setScrollConfiguration("showSV")} >
+              <Text style={styles.controlButtonText}>{'showSV:' + scrollConfigs["showSV"]}</Text>
+            </TouchableHighlight>
             <View style={[styles.controlButton,{width:50,height:50}]}>
               <Text style={styles.controlButtonText}>{scrollConfigs["childItemNum"]}</Text>
             </View>

--- a/packages/react-native-skia/components/scrollview/ScrollView-Demo.js
+++ b/packages/react-native-skia/components/scrollview/ScrollView-Demo.js
@@ -189,7 +189,7 @@ const SimpleViewApp = React.Node = () => {
             <TouchableHighlight underlayColor='darkseagreen' style={styles.controlButton} onPress={() => setScrollConfiguration("showSV")} >
               <Text style={styles.controlButtonText}>{'showSV:' + scrollConfigs["showSV"]}</Text>
             </TouchableHighlight>
-            <View style={[styles.controlButton,{width:50,height:50}]}>
+            <View style={[styles.controlButton,{width:100,height:50}]}>
               <Text style={styles.controlButtonText}>{scrollConfigs["childItemNum"]}</Text>
             </View>
             <View styles={{flexDirection:'column'}}>

--- a/packages/react-native-skia/components/scrollview/ScrollView_FocusableItems.js
+++ b/packages/react-native-skia/components/scrollview/ScrollView_FocusableItems.js
@@ -11,7 +11,7 @@ const {
   AppRegistry,
 } = require('react-native');
 
-const NUM_ITEMS = 25;
+const NUM_ITEMS = 250;
 
 class ScrollViewSimpleExample extends React.Component<{...}> {
   makeItems: (nItems: number, styles: any) => Array<any> = (
@@ -86,6 +86,7 @@ const styles = StyleSheet.create({
     borderColor: '#a52a2a',
     padding: 30,
     margin: 5,
+    height: 200,
   },
 });
 

--- a/packages/react-native-skia/components/scrollview/ScrollView_FocusableItems_NonFocusableItems.js
+++ b/packages/react-native-skia/components/scrollview/ScrollView_FocusableItems_NonFocusableItems.js
@@ -11,7 +11,7 @@ const {
   AppRegistry,
 } = require('react-native');
 
-const NUM_ITEMS = 25;
+const NUM_ITEMS = 250;
 
 class ScrollViewSimpleExample extends React.Component<{...}> {
   makeItems: (nItems: number, styles: any) => Array<any> = (
@@ -20,13 +20,13 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
   ): Array<any> => {
     const items = [];
     for (let i = 0; i < nItems; i++) {
-      if(i==3) {
+      if(!(i%8)) {
          items[i] = (
           <View key={i} style={{ backgroundColor: 'red', alignItems: 'center',borderRadius: 5, borderWidth: 5, borderColor: '#a52a2a', padding: 30, margin: 5, height:650}}>
             <Text>{'Item ' + i}</Text>
           </View>
          );
-      } else if ( i >10 && i < 15) {
+      } else if ( !(i % 5)) {
          items[i] = (
           <View key={i} style={{backgroundColor: 'orange', alignItems: 'center',borderRadius: 5, borderWidth: 5, borderColor: '#a52a2a', padding: 30, margin: 5}}>
             <Text>{'Item ' + i}</Text>
@@ -100,6 +100,7 @@ const styles = StyleSheet.create({
     borderColor: '#a52a2a',
     padding: 30,
     margin: 5,
+    height: 250,
   },
 });
 

--- a/packages/react-native-skia/components/scrollview/ScrollView_H_FocusableItems.js
+++ b/packages/react-native-skia/components/scrollview/ScrollView_H_FocusableItems.js
@@ -11,7 +11,7 @@ const {
   AppRegistry,
 } = require('react-native');
 
-const NUM_ITEMS = 25;
+const NUM_ITEMS = 250;
 
 class ScrollViewSimpleExample extends React.Component<{...}> {
   makeItems: (nItems: number, styles: any) => Array<any> = (
@@ -74,6 +74,7 @@ const styles = StyleSheet.create({
     borderColor: '#a52a2a',
     padding: 30,
     margin: 5,
+    width: 200,
   },
 });
 

--- a/packages/react-native-skia/components/scrollview/ScrollView_NonFocusableItems.js
+++ b/packages/react-native-skia/components/scrollview/ScrollView_NonFocusableItems.js
@@ -7,11 +7,12 @@ const {
   StyleSheet,
   Text,
   View,
+  Image,
   TouchableOpacity,
   AppRegistry,
 } = require('react-native');
 
-const NUM_ITEMS = 25;
+const NUM_ITEMS = 250;
 
 class ScrollViewSimpleExample extends React.Component<{...}> {
   makeItems: (nItems: number, styles: any) => Array<any> = (
@@ -23,6 +24,7 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
       items[i] = (
           <View key={i} style={styles}>
             <Text>{'Item ' + i}</Text>
+            <Image style={{width:50,height:50}} source={require('react-native/Libraries/NewAppScreen/components/logo.png')}></Image>
           </View>
         );
     }
@@ -68,6 +70,12 @@ const styles = StyleSheet.create({
     borderColor: '#a52a2a',
     padding: 30,
     margin: 5,
+    height: 350,
+  },
+  image: {
+    width: 125,
+    height: 100,
+    backgroundColor: "lightgreen"
   }
 });
 

--- a/packages/react-native-skia/components/scrollview/ScrollView_NonFocusableItems_Horizontal.js
+++ b/packages/react-native-skia/components/scrollview/ScrollView_NonFocusableItems_Horizontal.js
@@ -10,7 +10,7 @@ const {
   AppRegistry,
 } = require('react-native');
 
-const NUM_ITEMS = 25;
+const NUM_ITEMS = 250;
 
 class ScrollViewSimpleExample extends React.Component<{...}> {
   makeItems: (nItems: number, styles: any) => Array<any> = (
@@ -64,6 +64,7 @@ const styles = StyleSheet.create({
     borderColor: '#a52a2a',
     padding: 30,
     margin: 2,
+    width: 200,
   }
 });
 

--- a/packages/react-native-skia/components/view/SimpleDirtyAppWithOverflow.js
+++ b/packages/react-native-skia/components/view/SimpleDirtyAppWithOverflow.js
@@ -5,11 +5,33 @@ import { View, AppRegistry, Image, Text } from 'react-native';
 const SimpleViewApp = React.Node = () => {
 
   let [bgColor,setBgColor] = useState('yellow');
+  let [showChild,toggleChild] = useState(false);
+
+  setTimeout(()=>{
+      toggleChild(!showChild);
+  },2000);
 
   setTimeout(()=>{
       if(bgColor == 'yellow') setBgColor('orange');
       else setBgColor('yellow');
-  },3000);
+  },5000);
+
+  let childOverflow = () => {
+     if(showChild) {
+       return(
+         <View style={{backgroundColor:"pink",borderWidth:5,borderColor:'red',width:300,height:300,position:'absolute',top:550,left:100}}>
+           <View style={{backgroundColor:"grey",width:300,height:200,marginLeft:200,marginTop:50,overflow:"hidden"}}>
+             <View style={{backgroundColor:"lightcyan",width:100,height:200,marginLeft:50}}>
+             </View>
+             <View style={{backgroundColor:"lightcyan",width:100,height:200,marginLeft:50}}>
+             </View>
+             <View style={{backgroundColor:"lightcyan",width:100,height:200,marginLeft:50}}>
+             </View>
+           </View>
+         </View>
+       )
+     }
+  }
 
   return (
     <View
@@ -18,54 +40,56 @@ const SimpleViewApp = React.Node = () => {
                justifyContent: 'center',
                alignItems: 'center',
                backgroundColor: '#444' }}>
-      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:50,left:100}}>
+      <Text style={{position:"absolute",top:10,left:50}}>{"Overflow:Visible"}</Text>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:100,height:100,position:'absolute',top:50,left:50}}>
       </View>
-      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:50,left:500}}>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:100,height:100,position:'absolute',top:50,left:200}}>
       </View>
-      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:400,left:100}}>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:100,height:100,position:'absolute',top:200,left:50}}>
       </View>
-      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:400,left:500}}>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:100,height:100,position:'absolute',top:200,left:200}}>
       </View>
-      <View style={{backgroundColor:bgColor,borderWidth:5,borderColor:'red',width:300,height:400,position:'absolute',top:150,left:300,overflow:"visible"}}>
-         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+      <View style={{backgroundColor:bgColor,borderWidth:5,borderColor:'red',width:150,height:150,position:'absolute',top:100,left:100,overflow:"visible"}}>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
          </View>
-         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
          </View>
-         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
          </View>
-         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
          </View>
-         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
          </View>
-         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
          </View>
-     </View>
-     <View style={{backgroundColor:bgColor,borderWidth:5,borderColor:'red',width:300,height:50,position:'absolute',top:600,left:300}}>
-     </View>
-     <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:50,left:900}}>
-     </View>
-     <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:50,left:1300}}>
-     </View>
-     <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:400,left:900}}>
-     </View>
-     <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:400,left:1300}}>
-     </View>
-     <View style={{backgroundColor:bgColor,borderWidth:5,borderColor:'red',width:300,height:400,position:'absolute',top:150,left:1100,overflow:"hidden"}}>
-        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
-        </View>
-        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
-        </View>
-        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
-        </View>
-        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
-        </View>
-        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
-        </View>
-        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
-        </View>
-    </View>
-    <View style={{backgroundColor:bgColor,borderWidth:5,borderColor:'red',width:300,height:50,position:'absolute',top:600,left:1100}}>
-    </View>
+      </View>
+      <View style={{backgroundColor:bgColor,borderWidth:5,borderColor:'red',width:100,height:100,position:'absolute',top:150,left:100}}>
+      </View>
+      <Text style={{position:"absolute",top:10,left:350}}>{"Overflow:Hidden"}</Text>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:100,height:100,position:'absolute',top:50,left:350}}>
+      </View>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:100,height:100,position:'absolute',top:50,left:500}}>
+      </View>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:100,height:100,position:'absolute',top:200,left:350}}>
+      </View>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:100,height:100,position:'absolute',top:200,left:500}}>
+      </View>
+      <View style={{backgroundColor:bgColor,borderWidth:5,borderColor:'red',width:150,height:150,position:'absolute',top:100,left:400,overflow:"hidden"}}>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
+         </View>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
+         </View>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
+         </View>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
+         </View>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
+         </View>
+         <View style={{backgroundColor:"green",width:100,height:50,margin:5}}>
+         </View>
+      </View>
+      <Text style={{position:"absolute",top:500,left:100}}>{"Child Overflow:Hidden"}</Text>
+      {childOverflow()}
     </View>
   );
 };

--- a/packages/react-native-skia/components/view/SimpleDirtyAppWithOverflow.js
+++ b/packages/react-native-skia/components/view/SimpleDirtyAppWithOverflow.js
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import {useState} from 'react';
+import { View, AppRegistry, Image, Text } from 'react-native';
+
+const SimpleViewApp = React.Node = () => {
+
+  let [bgColor,setBgColor] = useState('yellow');
+
+  setTimeout(()=>{
+      if(bgColor == 'yellow') setBgColor('orange');
+      else setBgColor('yellow');
+  },3000);
+
+  return (
+    <View
+      style={{ flex: 1,
+               flexDirection: 'column',
+               justifyContent: 'center',
+               alignItems: 'center',
+               backgroundColor: '#444' }}>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:50,left:100}}>
+      </View>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:50,left:500}}>
+      </View>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:400,left:100}}>
+      </View>
+      <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:400,left:500}}>
+      </View>
+      <View style={{backgroundColor:bgColor,borderWidth:5,borderColor:'red',width:300,height:400,position:'absolute',top:150,left:300,overflow:"visible"}}>
+         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+         </View>
+         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+         </View>
+         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+         </View>
+         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+         </View>
+         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+         </View>
+         <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+         </View>
+     </View>
+     <View style={{backgroundColor:bgColor,borderWidth:5,borderColor:'red',width:300,height:50,position:'absolute',top:600,left:300}}>
+     </View>
+     <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:50,left:900}}>
+     </View>
+     <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:50,left:1300}}>
+     </View>
+     <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:400,left:900}}>
+     </View>
+     <View style={{backgroundColor:bgColor,borderWidth:2,borderColor:'black',width:300,height:300,position:'absolute',top:400,left:1300}}>
+     </View>
+     <View style={{backgroundColor:bgColor,borderWidth:5,borderColor:'red',width:300,height:400,position:'absolute',top:150,left:1100,overflow:"hidden"}}>
+        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+        </View>
+        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+        </View>
+        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+        </View>
+        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+        </View>
+        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+        </View>
+        <View style={{backgroundColor:"green",width:100,height:100,margin:5}}>
+        </View>
+    </View>
+    <View style={{backgroundColor:bgColor,borderWidth:5,borderColor:'red',width:300,height:50,position:'absolute',top:600,left:1100}}>
+    </View>
+    </View>
+  );
+};
+
+AppRegistry.registerComponent('SimpleViewApp', () => SimpleViewApp);

--- a/rns_shell/compositor/Compositor.cpp
+++ b/rns_shell/compositor/Compositor.cpp
@@ -9,6 +9,7 @@
 #include "include/core/SkPaint.h"
 #include "include/core/SkSurface.h"
 #include "include/core/SkCanvas.h"
+#include "include/core/SkRegion.h"
 
 #include "ReactSkia/utils/RnsLog.h"
 
@@ -78,22 +79,38 @@ void Compositor::invalidate() {
     backBuffer_ = nullptr;
 }
 
-SkRect Compositor::beginClip(PaintContext& context) {
+SkRect Compositor::beginClip(PaintContext& context, ClipType type) {
     SkRect clipBound = SkRect::MakeEmpty();
     if(context.damageRect.size() == 0)
         return clipBound;
 
-    SkPath clipPath = SkPath();
-    for (auto& rect : context.damageRect) {
-        RNS_LOG_DEBUG("Add Damage " << rect.x() << " " << rect.y() << " " << rect.width() << " " << rect.height());
-        clipPath.addRect(rect.left(), rect.top(), rect.right(), rect.bottom());
+    // Use clipPath for clipping
+    if(type == ClipTypePath) {
+        SkPath clipPath = SkPath();
+        for (auto& rect : context.damageRect) {
+            RNS_LOG_INFO("Add Damage " << rect.x() << " " << rect.y() << " " << rect.width() << " " << rect.height());
+            clipPath.addRect(rect.left(), rect.top(), rect.right(), rect.bottom());
+        }
+
+        if(clipPath.getBounds().isEmpty()) {
+            return clipBound;
+        }
+
+        context.canvas->clipPath(clipPath);
+        clipBound = clipPath.getBounds();
+
+    } else if(type == ClipTypeRegion) {
+        // Use clipRegion for clipping
+        SkRegion clipRgn(SkIRect::MakeEmpty());
+        clipRgn.setRects(context.damageRect.data(),context.damageRect.size());
+
+        if(clipRgn.getBounds().isEmpty()) {
+            return clipBound;
+        }
+
+        context.canvas->clipRegion(clipRgn);
+        clipBound = SkRect::Make(clipRgn.getBounds());
     }
-
-    if(clipPath.getBounds().isEmpty())
-        return clipBound;
-
-    context.canvas->clipPath(clipPath);
-    clipBound = clipPath.getBounds();
 
     return clipBound;
 }

--- a/rns_shell/compositor/Compositor.cpp
+++ b/rns_shell/compositor/Compositor.cpp
@@ -110,6 +110,7 @@ SkRect Compositor::beginClip(PaintContext& context, bool useClipRegion) {
 
     context.canvas->clipPath(clipPath);
     clipBound = clipPath.getBounds();
+
     return clipBound;
 }
 

--- a/rns_shell/compositor/Compositor.cpp
+++ b/rns_shell/compositor/Compositor.cpp
@@ -88,7 +88,7 @@ SkRect Compositor::beginClip(PaintContext& context, ClipType type) {
     if(type == ClipTypePath) {
         SkPath clipPath = SkPath();
         for (auto& rect : context.damageRect) {
-            RNS_LOG_INFO("Add Damage " << rect.x() << " " << rect.y() << " " << rect.width() << " " << rect.height());
+            RNS_LOG_DEBUG("Add Damage " << rect.x() << " " << rect.y() << " " << rect.width() << " " << rect.height());
             clipPath.addRect(rect.left(), rect.top(), rect.right(), rect.bottom());
         }
 

--- a/rns_shell/compositor/Compositor.cpp
+++ b/rns_shell/compositor/Compositor.cpp
@@ -94,22 +94,23 @@ SkRect Compositor::beginClip(PaintContext& context, bool useClipRegion) {
         }
 
         context.canvas->clipRegion(clipRgn);
-        return SkRect::Make(clipRgn.getBounds());
-    }
+        clipBound = SkRect::Make(clipRgn.getBounds());
 
-    // Use clipPath for clipping
-    SkPath clipPath = SkPath();
-    for (auto& rect : context.damageRect) {
-        RNS_LOG_DEBUG("Add Damage " << rect.x() << " " << rect.y() << " " << rect.width() << " " << rect.height());
-        clipPath.addRect(rect.left(), rect.top(), rect.right(), rect.bottom());
-    }
+    } else {
+        // Use clipPath for clipping
+        SkPath clipPath = SkPath();
+        for (auto& rect : context.damageRect) {
+            RNS_LOG_DEBUG("Add Damage " << rect.x() << " " << rect.y() << " " << rect.width() << " " << rect.height());
+            clipPath.addRect(rect.left(), rect.top(), rect.right(), rect.bottom());
+        }
 
-    if(clipPath.getBounds().isEmpty()) {
-        return clipBound;
-    }
+        if(clipPath.getBounds().isEmpty()) {
+            return clipBound;
+        }
 
-    context.canvas->clipPath(clipPath);
-    clipBound = clipPath.getBounds();
+        context.canvas->clipPath(clipPath);
+        clipBound = clipPath.getBounds();
+    }
 
     return clipBound;
 }

--- a/rns_shell/compositor/Compositor.h
+++ b/rns_shell/compositor/Compositor.h
@@ -19,6 +19,11 @@ namespace RnsShell {
 
 typedef uint64_t PlatformDisplayID;
 
+enum ClipType {
+    ClipTypePath = 0, // Use clipPath for clipping.This method transform their arguments by current matrix
+    ClipTypeRegion,   // Use clipRegion for clipping.This method does not apply transform and assumes arguments are absolutes
+};
+
 class Compositor {
     RNS_MAKE_NONCOPYABLE(Compositor);
 public:
@@ -48,7 +53,7 @@ public:
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
     GrDirectContext* getDirectContext(); // interface to expose directcontext of gpu backend
 #endif
-    static SkRect beginClip(PaintContext& context);
+    static SkRect beginClip(PaintContext& context, ClipType type=ClipTypePath);
 
 private:
 

--- a/rns_shell/compositor/Compositor.h
+++ b/rns_shell/compositor/Compositor.h
@@ -19,11 +19,6 @@ namespace RnsShell {
 
 typedef uint64_t PlatformDisplayID;
 
-enum ClipType {
-    ClipTypePath = 0, // Use clipPath for clipping.This method transform their arguments by current matrix
-    ClipTypeRegion,   // Use clipRegion for clipping.This method does not apply transform and assumes arguments are absolutes
-};
-
 class Compositor {
     RNS_MAKE_NONCOPYABLE(Compositor);
 public:
@@ -53,7 +48,7 @@ public:
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
     GrDirectContext* getDirectContext(); // interface to expose directcontext of gpu backend
 #endif
-    static SkRect beginClip(PaintContext& context, ClipType type=ClipTypePath);
+    static SkRect beginClip(PaintContext& context, bool useClipRegion=false);
 
 private:
 

--- a/rns_shell/compositor/Compositor.h
+++ b/rns_shell/compositor/Compositor.h
@@ -1,6 +1,6 @@
 /*
 * Copyright 2016 Google Inc.
-* Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+* Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
 *
 * Use of this source code is governed by a BSD-style license that can be
 * found in the LICENSE file.

--- a/rns_shell/compositor/layers/Layer.cpp
+++ b/rns_shell/compositor/layers/Layer.cpp
@@ -242,7 +242,7 @@ void Layer::paint(PaintContext& context) {
         if(!context.dirtyClipBound.isEmpty() && intRect.intersect(context.dirtyClipBound) == false) {
             RNS_LOG_WARN("We should not call paint if it doesnt intersect with non empty dirtyClipBound...");
         }
-        context.canvas->clipRect(intRect);
+        context.canvas->clipRect(intRect,SkClipOp::kIntersect);
     }
 
     paintChildren(context);

--- a/rns_shell/compositor/layers/Layer.cpp
+++ b/rns_shell/compositor/layers/Layer.cpp
@@ -220,9 +220,9 @@ void Layer::paintSelf(PaintContext& context) {
 void Layer::paintChildren(PaintContext& context) {
     for (auto& layer : children_) {
         if(layer->needsPainting(context)) {
-            RNS_LOG_DEBUG("Paint Layer(ID:" << layerId_ << ", ParentID:" << (parent_ ? parent_->layerId() : -1) <<
-                ") Frame [" << frame_.x() << "," << frame_.y() << "," << frame_.width() << "," << frame_.height() <<
-                "], Bounds [" << bounds_.x() << "," << bounds_.y() << "," << bounds_.width() << "," << bounds_.height() << "]");
+            RNS_LOG_DEBUG("Paint Layer(ID:" << layer->layerId_ << ", ParentID:" << layerId_ <<
+                ") Frame [" << layer->frame_.x() << "," << layer->frame_.y() << "," << layer->frame_.width() << "," << layer->frame_.height() <<
+                "], Bounds [" << layer->bounds_.x() << "," << layer->bounds_.y() << "," << layer->bounds_.width() << "," << layer->bounds_.height() << "]");
             layer->paint(context);
         }
     }

--- a/rns_shell/compositor/layers/Layer.cpp
+++ b/rns_shell/compositor/layers/Layer.cpp
@@ -238,11 +238,7 @@ void Layer::paint(PaintContext& context) {
     paintSelf(context); // First paint self and then children if any
 
     if(masksToBounds_) { // Need to clip children.
-        SkRect intRect = SkRect::Make(absFrame_);
-        //If scrolling offset available,check intRect with offset value
-        if(!context.offset.isZero()){
-            intRect.offset(context.offset.x(),context.offset.y());
-        }
+        SkRect intRect = SkRect::Make(frame_);
         if(!context.dirtyClipBound.isEmpty() && intRect.intersect(context.dirtyClipBound) == false) {
             RNS_LOG_WARN("We should not call paint if it doesnt intersect with non empty dirtyClipBound...");
         }

--- a/rns_shell/compositor/layers/PictureLayer.cpp
+++ b/rns_shell/compositor/layers/PictureLayer.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+* Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
 *
 * Use of this source code is governed by a BSD-style license that can be
 * found in the LICENSE file.

--- a/rns_shell/compositor/layers/PictureLayer.cpp
+++ b/rns_shell/compositor/layers/PictureLayer.cpp
@@ -16,7 +16,7 @@ SharedPictureLayer PictureLayer::Create(Client& layerClient) {
 
 PictureLayer::PictureLayer(Client& layerClient)
     : INHERITED(layerClient, LAYER_TYPE_PICTURE) {
-    RNS_LOG_INFO("Picture Layer Constructed(" << this << ") with ID : " << layerId() << " and LayerClient : " << &layerClient);
+    RNS_LOG_DEBUG("Picture Layer Constructed(" << this << ") with ID : " << layerId() << " and LayerClient : " << &layerClient);
 }
 
 void PictureLayer::paintSelf(PaintContext& context) {

--- a/rns_shell/compositor/layers/ScrollLayer.cpp
+++ b/rns_shell/compositor/layers/ScrollLayer.cpp
@@ -308,7 +308,7 @@ void ScrollLayer::prePaint(PaintContext& context, bool forceLayout) {
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
     //If bitmapReset,we have to draw all childrens.So add bitmap Rect as damageRect
     if(forceBitmapReset_) {
-        addDamageRect(bitmapContext,{0,0,contentSize_.width(),contentSize_.height()});
+        addDamageRect(bitmapPaintContext,{0,0,contentSize_.width(),contentSize_.height()});
     }
 #endif
 #endif

--- a/rns_shell/compositor/layers/ScrollLayer.cpp
+++ b/rns_shell/compositor/layers/ScrollLayer.cpp
@@ -412,7 +412,11 @@ void ScrollLayer::paintSelf(PaintContext& context) {
 #if !defined(GOOGLE_STRIP_LOG) || (GOOGLE_STRIP_LOG <= INFO)
     RNS_GET_TIME_STAMP_US(start);
 #endif
-
+    /* Paint self algorithm */
+    /*  1. Draw shadow using shadow picture playback */
+    /*  2. Draw visible rect of bitmap (srcRect) to parent canvas frame (dstRect) */
+    /*  3. Draw scroll bar (in bitmap mode)*/
+    /*  4. Draw border using border picture playback (in bitmap mode)*/
     if(shadowPicture()) {
         RNS_LOG_DEBUG("SkPicture ( "  << shadowPicture_ << " )For " <<
                 shadowPicture()->approximateOpCount() << " operations and size : " << shadowPicture()->approximateBytesUsed());
@@ -420,7 +424,6 @@ void ScrollLayer::paintSelf(PaintContext& context) {
     }
 
 #if USE(SCROLL_LAYER_BITMAP)
-
     if(drawDestRect_.isEmpty() || drawSrcRect_.isEmpty()) {
        drawDestRect_ = frame_;
        drawSrcRect_.setXYWH(scrollOffsetX_,scrollOffsetY_,frame_.width(),frame_.height());
@@ -438,6 +441,7 @@ void ScrollLayer::paintSelf(PaintContext& context) {
 
 #else
 
+    // We will draw only frame rect here, scrollbar and border will be drawn after childrens are drawn
     if(backgroundColor != SK_ColorTRANSPARENT) {
       SkPaint paint;
       paint.setColor(backgroundColor);
@@ -457,14 +461,13 @@ void ScrollLayer::paintSelfAndChildren(PaintContext& context) {
     RNS_GET_TIME_STAMP_US(start);
 #endif
     //Paint sequence
-    //1. Paint shadow on parent's canvas
-    //2. Paint self on parent's canvas
-    //3. Clip frame rect to ensure children do not draw outside area
-    //4. Update self scrollOffset with parent's scroll offset in paint context
-    //5. Paint children on parent's canvas
-    //6. Paint scroll bar on parent's canvas
-    //7. Paint border on parent's canvas
-    //8. Revert back updated scroll offset in paint context
+    //1. Paint self on parent's canvas(without scrollbar and border)
+    //2. Clip frame rect to ensure children do not draw outside area
+    //3. Update self scrollOffset with parent's scroll offset in paint context
+    //4. Paint children on parent's canvas
+    //5. Paint scroll bar on parent's canvas
+    //6. Paint border on parent's canvas
+    //7. Revert back updated scroll offset in paint context
 
     paintSelf(context);
 
@@ -496,10 +499,7 @@ void ScrollLayer::paintChildrenAndSelf(PaintContext& context) {
     //2. Clip path on bitmap based on damageRects on bitmap
     //3. Draw background color
     //4. Paint children on bitmap
-    //5. Paint border on parent's canvas
-    //6. Paint self on parent's canvas
-    //7. Paint scrollbar on parent's canvas
-    //8. Paint shadow on parent's canvas
+    //5. Paint self on parent's canvas
 
     PaintContext bitmapPaintContext = {
             scrollCanvas_.get(),  // canvas

--- a/rns_shell/compositor/layers/ScrollLayer.cpp
+++ b/rns_shell/compositor/layers/ScrollLayer.cpp
@@ -319,6 +319,12 @@ void ScrollLayer::prePaint(PaintContext& context, bool forceLayout) {
         /*As childrens of this layer are painted on bitmap canvas,we do not need parent frame here*/
         layer->setSkipParentMatrix(true);
 
+#if USE(SCROLL_LAYER_BITMAP)
+        if(forceBitmapReset_){
+          layer->invalidate();
+        }
+#endif
+
         RNS_LOG_DEBUG("Layer needs prePaint [" << layer->getBounds().x() <<"," << layer->getBounds().y() << "," << layer->getBounds().width() <<"," << layer->getBounds().height() << "]");
         layer->prePaint(bitmapPaintContext,forceChildrenLayout);
         if(layer->invalidateMask_ & LayerRemoveInvalidate) {
@@ -353,7 +359,7 @@ void ScrollLayer::prePaint(PaintContext& context, bool forceLayout) {
        //Calculate the screen frame for the child dirty frame and add intersected area to parent damageRect list
        for(auto &rect : bitmapSurfaceDamage_) {
            SkIRect screenDirtyRect = rect.makeOffset(-scrollOffsetX_,-scrollOffsetY_).makeOffset(absFrame_.x(),absFrame_.y());
-           RNS_LOG_INFO("Scroll Layer (" << layerId_ << ") damage rect [" << rect.x() << "," << rect.y() << "," << rect.width() << "," << rect.height()
+           RNS_LOG_TRACE("Scroll Layer (" << layerId_ << ") damage rect [" << rect.x() << "," << rect.y() << "," << rect.width() << "," << rect.height()
                             << "] absFrame point [" << absFrame_.x() << "," << absFrame_.y()
                             << "] screenDirtyRect [" << screenDirtyRect.x() << "," << screenDirtyRect.y() << "," << screenDirtyRect.width()
                             << "," << screenDirtyRect.height() << "]");

--- a/rns_shell/compositor/layers/ScrollLayer.cpp
+++ b/rns_shell/compositor/layers/ScrollLayer.cpp
@@ -387,6 +387,7 @@ void ScrollLayer::prePaint(PaintContext& context, bool forceLayout) {
     RNS_LOG_TRACE("====================================");
 #endif
 
+    //Need to retain RemoveInvalidate mask,since parent requires it for removal from its list
     invalidateMask_ = static_cast<LayerInvalidateMask>(invalidateMask_ & LayerRemoveInvalidate);
     recycleChildList.clear();
 #if USE(SCROLL_LAYER_BITMAP)

--- a/rns_shell/compositor/layers/ScrollLayer.h
+++ b/rns_shell/compositor/layers/ScrollLayer.h
@@ -104,7 +104,6 @@ private:
     sk_sp<SkPicture> borderPicture_;
 
     void paintSelfAndChildren(PaintContext& context);
-    inline void paintShadow(PaintContext& context);
     inline void paintBorder(PaintContext& context);
     inline void paintScrollBar(PaintContext& context);
 #if ENABLE(FEATURE_SCROLL_INDICATOR)

--- a/rns_shell/compositor/layers/ScrollLayer.h
+++ b/rns_shell/compositor/layers/ScrollLayer.h
@@ -104,6 +104,9 @@ private:
     sk_sp<SkPicture> borderPicture_;
 
     void paintSelfAndChildren(PaintContext& context);
+    inline void paintShadow(PaintContext& context);
+    inline void paintBorder(PaintContext& context);
+    inline void paintScrollBar(PaintContext& context);
 #if ENABLE(FEATURE_SCROLL_INDICATOR)
     ScrollBar scrollbar_;   // scroll indicator bar
 #endif


### PR DESCRIPTION
- Avoid resetting scroll layer invalidateMask in prePaint. We will be resetting the remove mask if it was set.
- Use clipRegion for handling partial updates in bitmap instead of clipPath which has limitation of dimensions
- Change sequence of draw scroll bar and border for non-bitmap mode
- Bitmap partial update was using old layer bounds to call child layer prePaint, this condition is been removed
- When bitmap is reset,set the bitmap rect as damage rect to ensure all child layers are redrawn
- Correct logic of handling overflow "hidden"
- Cosmetic changes in logging messages
- Update test apps to verify above changes.