### PR TITLE
Window Delegator Redesigned to work with History of commands

### DIFF
--- a/ReactSkia/sdk/OnScreenKeyBoard.cpp
+++ b/ReactSkia/sdk/OnScreenKeyBoard.cpp
@@ -986,8 +986,9 @@ void OnScreenKeyboard::sendDrawCommand(DrawCommands commands) {
    }
    auto pic = pictureRecorder_.finishRecordingAsPicture();
    if(pic.get()) {
-     RNS_LOG_DEBUG("SkPicture ( "  << pic << " )For " << commandKey << " :Command Count: "
-     pic.get()->approximateOpCount() << " operations and size : " << pic.get()->approximateBytesUsed());
+     RNS_LOG_DEBUG("SkPicture For " << commandKey << " :Command Count: " <<
+     pic.get()->approximateOpCount() << " operations and size : " << pic.get()->approximateBytesUsed() <<
+     " Dirty Rect Count : "<<dirtyRect.size());
    }
    if(oskState_== OSK_STATE_ACTIVE) commitDrawCall(commandKey,{dirtyRect,pic});
 }

--- a/ReactSkia/sdk/OnScreenKeyBoard.cpp
+++ b/ReactSkia/sdk/OnScreenKeyBoard.cpp
@@ -17,7 +17,7 @@
 namespace rns {
 namespace sdk {
 
-/* Onscreen Key Board is compose of below Internal Components in order::
+/* Onscreen Key Board composed of below Internal Components in order::
 1. Background + TI Title
  ______________________________
 |                              |

--- a/ReactSkia/sdk/OnScreenKeyBoard.cpp
+++ b/ReactSkia/sdk/OnScreenKeyBoard.cpp
@@ -968,7 +968,7 @@ void OnScreenKeyboard::sendDrawCommand(DrawCommands commands) {
      RNS_LOG_INFO("SkPicture ( "  << pic << " )For " <<
      pic.get()->approximateOpCount() << " operations and size : " << pic.get()->approximateBytesUsed());
    }
-   if(oskState_== OSK_STATE_ACTIVE) commitDrawCall(commandKey,pic);
+   if(oskState_== OSK_STATE_ACTIVE) commitDrawCall(commandKey,{dirtyRect,pic});
 }
 
 } // namespace sdk

--- a/ReactSkia/sdk/OnScreenKeyBoard.cpp
+++ b/ReactSkia/sdk/OnScreenKeyBoard.cpp
@@ -180,9 +180,14 @@ void OnScreenKeyboard::launchOSKWindow() {
 
 //Finally Creating OSK Window
   std::function<void()> createWindowCB = std::bind(&OnScreenKeyboard::windowReadyToDrawCB,this);
+<<<<<<< HEAD
   std::function<void()> forceFullScreenDrawCB = std::bind(&OnScreenKeyboard::drawOSK,this);
   createWindow(screenSize_,createWindowCB,forceFullScreenDrawCB);
 
+=======
+  std::function<void()> faileSafeCB = std::bind(&OnScreenKeyboard::drawOSK,this);
+  createWindow(screenSize_,createWindowCB,faileSafeCB);
+>>>>>>> Added logic of maintain History and playback from history
 }
 
 void OnScreenKeyboard::drawPlaceHolderDisplayString() {
@@ -946,25 +951,23 @@ void OnScreenKeyboard::repeatKeyProcessingThread(){
 void OnScreenKeyboard::sendDrawCommand(DrawCommands commands) {
    std::scoped_lock lock(conditionalLockMutex);
    SkPictureRecorder pictureRecorder_;
+   std::string commandKey;
    pictureCanvas_ = pictureRecorder_.beginRecording(SkRect::MakeXYWH(0, 0, screenSize_.width(), screenSize_.height()));
    switch(commands) {
      case DRAW_PH_STRING:
        RNS_LOG_INFO("@@@ Got Task to work:DRAW_PH_STRING@@");
        drawPlaceHolderDisplayString();
-       if(lastFocussIndex_ == currentFocussIndex_) {
+       commandKey="EmbededTIString";
          break; // else continue to draw Highlight
-      }
       case DRAW_HL:
         RNS_LOG_INFO("@@@ Got Task to work:DRAW_HL@@");
+        commandKey="HighLight";
         drawHighLightOnKey(currentFocussIndex_);
       break;
      case DRAW_KB:
        RNS_LOG_INFO("@@@ Got Task to work:DRAW_KB@@");
+       commandKey="KeyBoardLayout";
        drawKBLayout(OSK_ALPHA_NUMERIC_KB);
-     break;
-     case DRAW_KEY:
-       RNS_LOG_INFO("@@@ Got Task to work:DRAW_KEY@@");
-       drawKBKeyFont(oskLayout_.returnKeyIndex);
      break;
      default:
      break;
@@ -974,7 +977,7 @@ void OnScreenKeyboard::sendDrawCommand(DrawCommands commands) {
      RNS_LOG_INFO("SkPicture ( "  << pic << " )For " <<
      pic.get()->approximateOpCount() << " operations and size : " << pic.get()->approximateBytesUsed());
    }
-   if(oskState_== OSK_STATE_ACTIVE) commitDrawCall(pic);
+   if(oskState_== OSK_STATE_ACTIVE) commitDrawCall(commandKey,pic);
 }
 
 } // namespace sdk

--- a/ReactSkia/sdk/OnScreenKeyBoard.cpp
+++ b/ReactSkia/sdk/OnScreenKeyBoard.cpp
@@ -18,7 +18,7 @@ namespace rns {
 namespace sdk {
 
 std::mutex oskLaunchExitCtrlMutex;//For synchronized OSK Launch & Exit
-std::mutex conditionalLockMutex;
+std::mutex drawCtrlLockMutex;
 
 OnScreenKeyboard& OnScreenKeyboard::getInstance() {
   static OnScreenKeyboard oskHandle;
@@ -948,7 +948,7 @@ void OnScreenKeyboard::repeatKeyProcessingThread(){
 #endif
 
 void OnScreenKeyboard::sendDrawCommand(DrawCommands commands) {
-   std::scoped_lock lock(conditionalLockMutex);
+   std::scoped_lock lock(drawCtrlLockMutex);
    SkPictureRecorder pictureRecorder_;
    std::string commandKey;
    std::vector<SkIRect>   dirtyRect;

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -119,6 +119,13 @@ class OnScreenKeyboard : public WindowDelegator{
       OSK_STATE_EXIT_INPROGRESS,
       OSK_STATE_INACTIVE,
     };
+    enum DrawCommands {
+      DRAW_PH_STRING,
+      DRAW_KB,
+      DRAW_HL,
+      DRAW_OSK,
+      DRAW_MAX
+    };
     struct OSKLayout {
       KBLayoutKeyInfoContainer*  keyInfo;
       KBLayoutKeyPosContainer*    keyPos;

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -120,10 +120,10 @@ class OnScreenKeyboard : public WindowDelegator{
       OSK_STATE_INACTIVE,
     };
     enum DrawCommands {
-      DRAW_OSK_BG,
-      DRAW_PH_STRING,
-      DRAW_KB,
-      DRAW_HL,
+      DRAW_OSK_BG, // Draw OSK Window Background
+      DRAW_PH_STRING, // Draw PlaceHolder String
+      DRAW_KB, // Draw KeyBoard Layout
+      DRAW_HL, // Draw Highlighted Key
       DRAW_MAX
     };
     struct OSKLayout {

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -120,7 +120,7 @@ class OnScreenKeyboard : public WindowDelegator{
       OSK_STATE_INACTIVE,
     };
     enum OSKComponents {
-      OSK_BACKGROUND,
+      OSK_BACKGROUND_AND_TI_TITLE,
       OSK_TEXTINPUT_DISPLAY,
       OSK_KEYBOARD_LAYOUT,
       OSK_KEYS
@@ -163,7 +163,7 @@ class OnScreenKeyboard : public WindowDelegator{
 
     void emitOSKKeyEvent(rnsKey keyValue);
     void windowReadyToDrawCB();
-    void triggerRenderRequestFor(OSKComponents components);
+    void triggerRenderRequest(OSKComponents components,bool batchRenderRequest=false);
 
     void drawHighLightOnKey(std::vector<SkIRect> &dirtyRect);
     void drawOSKBackGround(std::vector<SkIRect> &dirtyRect);

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -162,6 +162,7 @@ class OnScreenKeyboard : public WindowDelegator{
 
     void emitOSKKeyEvent(rnsKey keyValue);
     void windowReadyToDrawCB();
+    void sendDrawCommand(DrawCommands commands);
 
     void drawHighLightOnKey(SkPoint index);
     void drawOSKBackGround();

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -119,12 +119,11 @@ class OnScreenKeyboard : public WindowDelegator{
       OSK_STATE_EXIT_INPROGRESS,
       OSK_STATE_INACTIVE,
     };
-    enum DrawCommands {
-      DRAW_OSK_BACKGROUND,
-      DRAW_TEXTINPUT_STRING,
-      DRAW_KEYBOARD_LAYOUT,
-      DRAW_KEYS,
-      DRAW_MAX
+    enum OSKComponents {
+      OSK_BACKGROUND,
+      OSK_TEXTINPUT_DISPLAY,
+      OSK_KEYBOARD_LAYOUT,
+      OSK_KEYS
     };
     struct OSKLayout {
       KBLayoutKeyInfoContainer*  keyInfo;
@@ -164,7 +163,7 @@ class OnScreenKeyboard : public WindowDelegator{
 
     void emitOSKKeyEvent(rnsKey keyValue);
     void windowReadyToDrawCB();
-    void sendDrawCommand(DrawCommands commands);
+    void triggerRenderRequestFor(OSKComponents components);
 
     void drawHighLightOnKey(std::vector<SkIRect> &dirtyRect);
     void drawOSKBackGround(std::vector<SkIRect> &dirtyRect);

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -207,6 +207,7 @@ class OnScreenKeyboard : public WindowDelegator{
     std::atomic<bool> waitingForKeyConsumedSignal_{false};
 #endif /*ENABLE_FEATURE_KEY_THROTTLING*/
     SkCanvas*     pictureCanvas_{nullptr};
+    SkIRect       dirtyRect;
 };
 
 }// namespace sdk

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -138,6 +138,8 @@ class OnScreenKeyboard : public WindowDelegator{
       SkScalar          horizontalStartOffset;
       // PlaceHolder Title
       SkScalar          placeHolderTitleVerticalStart;
+      //KB Layout
+      SkScalar          kBHeight;
       // Place Holder
       SkScalar          placeHolderLength;
       SkScalar          placeHolderHeight;
@@ -207,7 +209,6 @@ class OnScreenKeyboard : public WindowDelegator{
     std::atomic<bool> waitingForKeyConsumedSignal_{false};
 #endif /*ENABLE_FEATURE_KEY_THROTTLING*/
     SkCanvas*     pictureCanvas_{nullptr};
-    SkIRect       dirtyRect;
 };
 
 }// namespace sdk

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -120,10 +120,10 @@ class OnScreenKeyboard : public WindowDelegator{
       OSK_STATE_INACTIVE,
     };
     enum DrawCommands {
-      DRAW_OSK_BG, // Draw OSK Window Background
-      DRAW_PH_STRING, // Draw PlaceHolder String
-      DRAW_KB, // Draw KeyBoard Layout
-      DRAW_HL, // Draw Highlighted Key
+      DRAW_OSK_BACKGROUND,
+      DRAW_TEXTINPUT_STRING,
+      DRAW_KEYBOARD_LAYOUT,
+      DRAW_KEYS,
       DRAW_MAX
     };
     struct OSKLayout {
@@ -172,6 +172,8 @@ class OnScreenKeyboard : public WindowDelegator{
     void drawKBLayout(std::vector<SkIRect> &dirtyRect);
     void drawKBKeyFont(SkPoint index,bool onHLTile=false);
     static inline void onScreenKeyboardEventEmit(std::string eventType);
+
+    std::mutex oskActiontCtrlMutex_;
 
 // Members for OSK Layout & sytling
     OSKConfig     oskConfig_;

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -198,6 +198,7 @@ class OnScreenKeyboard : public WindowDelegator{
     sem_t         sigKeyConsumed_;
     std::atomic<bool> waitingForKeyConsumedSignal_{false};
 #endif /*ENABLE_FEATURE_KEY_THROTTLING*/
+    SkCanvas*     pictureCanvas_{nullptr};
 };
 
 }// namespace sdk

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -166,10 +166,10 @@ class OnScreenKeyboard : public WindowDelegator{
     void windowReadyToDrawCB();
     void sendDrawCommand(DrawCommands commands);
 
-    void drawHighLightOnKey(SkPoint index);
-    void drawOSKBackGround();
-    void drawPlaceHolderDisplayString();
-    void drawKBLayout(OSKTypes oskType);
+    void drawHighLightOnKey(std::vector<SkIRect> &dirtyRect);
+    void drawOSKBackGround(std::vector<SkIRect> &dirtyRect);
+    void drawPlaceHolderDisplayString(std::vector<SkIRect> &dirtyRect);
+    void drawKBLayout(std::vector<SkIRect> &dirtyRect);
     void drawKBKeyFont(SkPoint index,bool onHLTile=false);
     static inline void onScreenKeyboardEventEmit(std::string eventType);
 

--- a/ReactSkia/sdk/OnScreenKeyBoard.h
+++ b/ReactSkia/sdk/OnScreenKeyBoard.h
@@ -120,10 +120,10 @@ class OnScreenKeyboard : public WindowDelegator{
       OSK_STATE_INACTIVE,
     };
     enum DrawCommands {
+      DRAW_OSK_BG,
       DRAW_PH_STRING,
       DRAW_KB,
       DRAW_HL,
-      DRAW_OSK,
       DRAW_MAX
     };
     struct OSKLayout {
@@ -164,7 +164,7 @@ class OnScreenKeyboard : public WindowDelegator{
     void windowReadyToDrawCB();
 
     void drawHighLightOnKey(SkPoint index);
-    void drawOSK();
+    void drawOSKBackGround();
     void drawPlaceHolderDisplayString();
     void drawKBLayout(OSKTypes oskType);
     void drawKBKeyFont(SkPoint index,bool onHLTile=false);

--- a/ReactSkia/sdk/WindowDelegator.cpp
+++ b/ReactSkia/sdk/WindowDelegator.cpp
@@ -66,8 +66,9 @@ void WindowDelegator::closeWindow() {
   RNS_LOG_TODO("Sync between rendering & Exit to be handled ");
   windowActive = false;
   std::scoped_lock lock(renderCtrlMutex_);
-  if(ownsTaskrunner_) windowTaskRunner_->stop();
-
+  if(ownsTaskrunner_){
+   windowTaskRunner_->stop();
+  }
   if(ownsTaskrunner_) {
     windowTaskRunner_->stop();
   }

--- a/ReactSkia/sdk/WindowDelegator.cpp
+++ b/ReactSkia/sdk/WindowDelegator.cpp
@@ -104,40 +104,41 @@ inline void WindowDelegator::renderToDisplay(std::string keyRef,sk_sp<SkPicture>
   std::scoped_lock lock(renderCtrlMutex);
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
   if(!keyRef.empty()) {
-   RNS_LOG_ERROR("keyRef :: "<<keyRef<< "Map Size : "<<drawHistorybin_.size());
-    drawHistorybin_.insert(std::pair<std::string, sk_sp<SkPicture>>(keyRef,pictureObj));
+    drawHistorybin_[keyRef]=pictureObj;
+    RNS_LOG_ERROR("keyRef :: "<<keyRef<< "Map Size : "<<drawHistorybin_.size());
   }
+  RNS_LOG_INFO("keyNameBasePicCommand_ :: "<<keyNameBasePicCommand_);
   int bufferAge=windowContext_->bufferAge();
   if(bufferAge != 1) {
 // Forcing full screen redraw as damage region handling is not done
-    RNS_LOG_ERROR("@@@@@@@@ drawPicture : Force Redraw@@@@@@@@@");
-    if(fullSCreenPictureObj_.get()) {
-      RNS_LOG_INFO("SkPicture ( "  << fullSCreenPictureObj_ << " )For " <<
-      fullSCreenPictureObj_.get()->approximateOpCount() << " operations and size : " << fullSCreenPictureObj_.get()->approximateBytesUsed());
-    }
-    if((bufferAge ==0) && fullSCreenPictureObj_.get()) {
-      fullSCreenPictureObj_->playback(windowDelegatorCanvas_);
+    if(bufferAge==0) {
+        std::map<std::string,sk_sp<SkPicture>>::iterator it = drawHistorybin_.find(keyNameBasePicCommand_);
+        if(it!=drawHistorybin_.end()){
+          if(it->second.get()) {
+            RNS_LOG_INFO("SkPicture ( "  << it->second << " )For " <<
+                it->second.get()->approximateOpCount() << " operations and size : " << it->second.get()->approximateBytesUsed());
+            it->second->playback(windowDelegatorCanvas_);
+            RNS_LOG_ERROR("Draw Base Command: keyRef :: "<<it->first<< "Map Size : "<<drawHistorybin_.size());
+          }
+        }
     }
     std::map<std::string,sk_sp<SkPicture>>::reverse_iterator it = drawHistorybin_.rbegin();
-    int count=1;
-    while( (it != drawHistorybin_.rend()) && bufferAge ) {
-      if(count > drawHistorybin_.size()) break;
-      if(it->second.get()) {
+    for( ;it != drawHistorybin_.rend() ;it++ ) {
+      if(it->second.get() && ((it->first).compare(keyNameBasePicCommand_))) {
         RNS_LOG_INFO("SkPicture ( "  << it->second << " )For " <<
                 it->second.get()->approximateOpCount() << " operations and size : " << it->second.get()->approximateBytesUsed());
         it->second->playback(windowDelegatorCanvas_);
-        RNS_LOG_ERROR("keyRef :: "<<it->first<< "Map Size : "<<drawHistorybin_.size());
-        count++;
+        RNS_LOG_ERROR("Draw Rest Of commands :keyRef :: "<<it->first<< "Map Size : "<<drawHistorybin_.size());
       }
-      bufferAge--;
     }
-  }else
+  } else
 #endif/*RNS_SHELL_HAS_GPU_SUPPORT*/
   {
     if(pictureObj.get()) {
         RNS_LOG_INFO("SkPicture ( "  << pictureObj << " )For " <<
                 pictureObj.get()->approximateOpCount() << " operations and size : " << pictureObj.get()->approximateBytesUsed());
       pictureObj->playback(windowDelegatorCanvas_);
+      RNS_LOG_ERROR("Draw Current Command :keyRef :: "<<keyRef<< "Map Size : "<<drawHistorybin_.size());
     }
   }
   if(backBuffer_)  backBuffer_->flushAndSubmit();

--- a/ReactSkia/sdk/WindowDelegator.cpp
+++ b/ReactSkia/sdk/WindowDelegator.cpp
@@ -12,7 +12,7 @@
 
 namespace rns {
 namespace sdk {
-/* 
+/*
  *> Window & Canvas created for Client and maintained with in window delegator
  *> Supports Partial Update with dirty Rect
  *> Maintains last updated picture command + dirty Rect for each components

--- a/ReactSkia/sdk/WindowDelegator.cpp
+++ b/ReactSkia/sdk/WindowDelegator.cpp
@@ -89,10 +89,9 @@ void WindowDelegator::closeWindow() {
 
 void WindowDelegator::commitDrawCall() {
   if(!windowActive) return;
-
   if( ownsTaskrunner_ )  {
     if( windowTaskRunner_->running() )
-      windowTaskRunner_->dispatch([&](){ renderToDisplay(); });
+      windowTaskRunner_->dispatch([=](){ renderToDisplay(pictureObj); });
   } else {
     renderToDisplay();
   }
@@ -102,6 +101,14 @@ inline void WindowDelegator::renderToDisplay() {
   if(!windowActive) return;
 
   std::scoped_lock lock(renderCtrlMutex);
+    if(fullSCreenPictureObj_.get()) {
+        RNS_LOG_INFO("SkPicture ( "  << fullSCreenPictureObj_ << " )For " <<
+            fullSCreenPictureObj_.get()->approximateOpCount() << " operations and size : " << fullSCreenPictureObj_.get()->approximateBytesUsed());
+    }
+    if(pictureObj.get()) {
+        RNS_LOG_INFO("SkPicture ( "  << pictureObj << " )For " <<
+                pictureObj.get()->approximateOpCount() << " operations and size : " << pictureObj.get()->approximateBytesUsed());
+    }
 
 #if USE(RNS_SHELL_PARTIAL_UPDATES) && defined(RNS_SHELL_HAS_GPU_SUPPORT)
   int bufferAge=windowContext_->bufferAge();

--- a/ReactSkia/sdk/WindowDelegator.cpp
+++ b/ReactSkia/sdk/WindowDelegator.cpp
@@ -12,11 +12,10 @@ namespace rns {
 namespace sdk {
 
 #define MAX_HISTORY_BIN_SIZE 4
-void WindowDelegator::createWindow(SkSize windowSize,std::function<void ()> windowReadyCB,std::function<void ()>forceFullScreenDraw,bool runOnTaskRunner) {
+void WindowDelegator::createWindow(SkSize windowSize,std::function<void ()> windowReadyCB,bool runOnTaskRunner) {
 
   windowSize_=windowSize;
   windowReadyTodrawCB_=windowReadyCB;
-  forceFullScreenDraw_=forceFullScreenDraw;
 
   if(runOnTaskRunner) {
     ownsTaskrunner_ = runOnTaskRunner;

--- a/ReactSkia/sdk/WindowDelegator.cpp
+++ b/ReactSkia/sdk/WindowDelegator.cpp
@@ -135,18 +135,17 @@ inline void WindowDelegator::renderToDisplay(std::string pictureCommandKey,Pictu
 
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
   int bufferAge=windowContext_->bufferAge();
-  if(!pictureCommandKey.empty() && (bufferAge == 1)) {
-// Add last updated area of current component to dirty Rect
-    auto iter=componentCommandBin_.find(pictureCommandKey);
-    if(iter != componentCommandBin_.end()) {
-      RNS_LOG_ERROR("Updating old dirty Rect");
-      #if USE(RNS_SHELL_PARTIAL_UPDATES)
-      if(supportsPartialUpdate_) {
+
+  #if USE(RNS_SHELL_PARTIAL_UPDATES)
+    if(supportsPartialUpdate_ && !pictureCommandKey.empty() && (bufferAge == 1)) {
+  // Add last updated area of current component to dirty Rect
+      auto iter=componentCommandBin_.find(pictureCommandKey);
+      if(iter != componentCommandBin_.end()) {
+        RNS_LOG_ERROR("Updating old dirty Rect");
         generateDirtyRect(dirtyRect,iter->second.dirtyRect);
       }
-      #endif/*RNS_SHELL_PARTIAL_UPDATES*/
     }
-  }
+  #endif/*RNS_SHELL_PARTIAL_UPDATES*/
 
   componentCommandBin_[pictureCommandKey]=pictureObj;
   RNS_LOG_DEBUG("Count of component for this window :: "<< componentCommandBin_.size());

--- a/ReactSkia/sdk/WindowDelegator.cpp
+++ b/ReactSkia/sdk/WindowDelegator.cpp
@@ -11,6 +11,7 @@
 namespace rns {
 namespace sdk {
 
+#define MAX_HISTORY_BIN_SIZE 4
 void WindowDelegator::createWindow(SkSize windowSize,std::function<void ()> windowReadyCB,std::function<void ()>forceFullScreenDraw,bool runOnTaskRunner) {
 
   windowSize_=windowSize;
@@ -87,42 +88,58 @@ void WindowDelegator::closeWindow() {
   windowReadyTodrawCB_=nullptr;
 }
 
-void WindowDelegator::commitDrawCall() {
+void WindowDelegator::commitDrawCall(std::string keyRef,sk_sp<SkPicture> pictureObj) {
   if(!windowActive) return;
   if( ownsTaskrunner_ )  {
     if( windowTaskRunner_->running() )
-      windowTaskRunner_->dispatch([=](){ renderToDisplay(pictureObj); });
+      windowTaskRunner_->dispatch([=](){ renderToDisplay(keyRef,pictureObj); });
   } else {
-    renderToDisplay();
+    renderToDisplay(keyRef,pictureObj);
   }
 }
 
-inline void WindowDelegator::renderToDisplay() {
+inline void WindowDelegator::renderToDisplay(std::string keyRef,sk_sp<SkPicture> pictureObj) {
   if(!windowActive) return;
 
   std::scoped_lock lock(renderCtrlMutex);
-
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
+  if(!keyRef.empty()) {
+   RNS_LOG_ERROR("keyRef :: "<<keyRef<< "Map Size : "<<drawHistorybin_.size());
+    drawHistorybin_.insert(std::pair<std::string, sk_sp<SkPicture>>(keyRef,pictureObj));
+  }
   int bufferAge=windowContext_->bufferAge();
-  if((bufferAge != 1) && (forceFullScreenDraw_)) {
+  if(bufferAge != 1) {
 // Forcing full screen redraw as damage region handling is not done
     RNS_LOG_ERROR("@@@@@@@@ drawPicture : Force Redraw@@@@@@@@@");
     if(fullSCreenPictureObj_.get()) {
-        RNS_LOG_INFO("SkPicture ( "  << fullSCreenPictureObj_ << " )For " <<
-            fullSCreenPictureObj_.get()->approximateOpCount() << " operations and size : " << fullSCreenPictureObj_.get()->approximateBytesUsed());
+      RNS_LOG_INFO("SkPicture ( "  << fullSCreenPictureObj_ << " )For " <<
+      fullSCreenPictureObj_.get()->approximateOpCount() << " operations and size : " << fullSCreenPictureObj_.get()->approximateBytesUsed());
     }
-    fullSCreenPictureObj_->playback(windowDelegatorCanvas_);
-  } else
+    if((bufferAge ==0) && fullSCreenPictureObj_.get()) {
+      fullSCreenPictureObj_->playback(windowDelegatorCanvas_);
+    }
+    std::map<std::string,sk_sp<SkPicture>>::reverse_iterator it = drawHistorybin_.rbegin();
+    int count=1;
+    while( (it != drawHistorybin_.rend()) && bufferAge ) {
+      if(count > drawHistorybin_.size()) break;
+      if(it->second.get()) {
+        RNS_LOG_INFO("SkPicture ( "  << it->second << " )For " <<
+                it->second.get()->approximateOpCount() << " operations and size : " << it->second.get()->approximateBytesUsed());
+        it->second->playback(windowDelegatorCanvas_);
+        RNS_LOG_ERROR("keyRef :: "<<it->first<< "Map Size : "<<drawHistorybin_.size());
+        count++;
+      }
+      bufferAge--;
+    }
+  }else
 #endif/*RNS_SHELL_HAS_GPU_SUPPORT*/
   {
-    RNS_LOG_ERROR("@@@@@@@@ drawPicture : Normal Draw @@@@@@@@@");
     if(pictureObj.get()) {
         RNS_LOG_INFO("SkPicture ( "  << pictureObj << " )For " <<
                 pictureObj.get()->approximateOpCount() << " operations and size : " << pictureObj.get()->approximateBytesUsed());
+      pictureObj->playback(windowDelegatorCanvas_);
     }
-    pictureObj->playback(windowDelegatorCanvas_);
   }
-
   if(backBuffer_)  backBuffer_->flushAndSubmit();
   if(windowContext_) {
     std::vector<SkIRect> emptyRect;// No partialUpdate handled , so passing emptyRect instead of dirtyRect

--- a/ReactSkia/sdk/WindowDelegator.cpp
+++ b/ReactSkia/sdk/WindowDelegator.cpp
@@ -97,9 +97,6 @@ void WindowDelegator::closeWindow() {
   if(ownsTaskrunner_){
    windowTaskRunner_->stop();
   }
-  if(ownsTaskrunner_) {
-    windowTaskRunner_->stop();
-  }
   if (workerThread_.joinable() ) {
     workerThread_.join();
   }

--- a/ReactSkia/sdk/WindowDelegator.h
+++ b/ReactSkia/sdk/WindowDelegator.h
@@ -22,7 +22,7 @@ namespace rns {
 namespace sdk {
 
 struct pictureCommand {
-  SkIRect dirtyRect;
+  std::vector<SkIRect> dirtyRect;
   sk_sp<SkPicture> pictureCommand;
 };
 

--- a/ReactSkia/sdk/WindowDelegator.h
+++ b/ReactSkia/sdk/WindowDelegator.h
@@ -36,14 +36,14 @@ class WindowDelegator {
     void createWindow(SkSize windowSize,std::function<void ()> windowReadyTodrawCB,bool runOnTaskRunner=true);
     void closeWindow();
     void setWindowTittle(const char* titleString);
-    void commitDrawCall(std::string keyRef,PictureObject pictureObj);
-    void setBasePicCommand(std::string keyName) {keyNameBasePicCommand_=keyName;}
+    void commitDrawCall(std::string pictureCommandKey,PictureObject pictureObj);
+    void setBasePicCommand(std::string keyName) {basePictureCommandKey_=keyName;}
 
   private:
     void onExposeHandler(RnsShell::Window* window);
     void windowWorkerThread();
     void createNativeWindow();
-    void renderToDisplay(std::string keyRef,PictureObject pictureObj);
+    void renderToDisplay(std::string pictureCommandKey,PictureObject pictureObj);
 
     std::unique_ptr<RnsShell::WindowContext> windowContext_{nullptr};
     RnsShell::Window* window_{nullptr};
@@ -55,7 +55,7 @@ class WindowDelegator {
     bool ownsTaskrunner_{false};
 /* members to fullfill X11 suggestion of "draw on receiving expose event to avoid data loss" */
     sem_t semReadyToDraw_;
-    std::mutex renderCtrlMutex;
+    std::mutex renderCtrlMutex_;
     std::thread workerThread_;
 
     std::function<void ()> windowReadyTodrawCB_{nullptr};
@@ -66,7 +66,7 @@ class WindowDelegator {
     bool windowActive{false};
 
     std::map<std::string,PictureObject> drawHistorybin_;
-    std::string keyNameBasePicCommand_;
+    std::string basePictureCommandKey_;
 };
 
 } // namespace sdk

--- a/ReactSkia/sdk/WindowDelegator.h
+++ b/ReactSkia/sdk/WindowDelegator.h
@@ -44,12 +44,14 @@ class WindowDelegator {
     void windowWorkerThread();
     void createNativeWindow();
     void renderToDisplay(std::string pictureCommandKey,PictureObject pictureObj);
-    void appendDirtyRect(std::vector<SkIRect> &dirtyRectVec ,std::vector<SkIRect> &componentDirtRectVec);
-
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+    void generateDirtyRect(std::vector<SkIRect> &dirtyRectVec ,std::vector<SkIRect> &componentDirtRectVec);
+#endif/*RNS_SHELL_PARTIAL_UPDATES*/
     std::unique_ptr<RnsShell::WindowContext> windowContext_{nullptr};
     RnsShell::Window* window_{nullptr};
     sk_sp<SkSurface>  backBuffer_;
     SkCanvas *windowDelegatorCanvas_{nullptr};
+    bool supportsPartialUpdate_{false};
 
 /*To fulfill OpenGl requirement of create & rendering to be handled from same thread context*/
     std::unique_ptr<RnsShell::TaskLoop> windowTaskRunner_{nullptr};

--- a/ReactSkia/sdk/WindowDelegator.h
+++ b/ReactSkia/sdk/WindowDelegator.h
@@ -7,7 +7,7 @@
 
 #include <semaphore.h>
 #include <thread>
-#include <vector>
+#include <map>
 
 #include "include/core/SkCanvas.h"
 
@@ -28,15 +28,13 @@ class WindowDelegator {
     void createWindow(SkSize windowSize,std::function<void ()> windowReadyTodrawCB,std::function<void ()> forceFullScreenDraw=nullptr,bool runOnTaskRunner=true);
     void closeWindow();
     void setWindowTittle(const char* titleString);
-
-    void commitDrawCall(sk_sp<SkPicture> pictureObj);
+    void commitDrawCall(std::string keyRef,sk_sp<SkPicture> pictureObj);
     void setFullScreenPicture(sk_sp<SkPicture> pictureObj) {fullSCreenPictureObj_=pictureObj;}
-
   private:
     void onExposeHandler(RnsShell::Window* window);
     void windowWorkerThread();
     void createNativeWindow();
-    void renderToDisplay();
+    void renderToDisplay(std::string keyRef,sk_sp<SkPicture> pictureObj);
 
     std::unique_ptr<RnsShell::WindowContext> windowContext_{nullptr};
     RnsShell::Window* window_{nullptr};
@@ -60,7 +58,7 @@ class WindowDelegator {
     SkSize windowSize_;
     bool windowActive{false};
 
-    std::vector<sk_sp<SkPicture>> drawHistorybin_;
+    std::map<std::string,sk_sp<SkPicture>> drawHistorybin_;
 };
 
 } // namespace sdk

--- a/ReactSkia/sdk/WindowDelegator.h
+++ b/ReactSkia/sdk/WindowDelegator.h
@@ -21,22 +21,29 @@
 namespace rns {
 namespace sdk {
 
+struct pictureCommand {
+  SkIRect dirtyRect;
+  sk_sp<SkPicture> pictureCommand;
+};
+
+typedef struct pictureCommand PictureObject;
 class WindowDelegator {
   public:
+
     WindowDelegator(){};
    ~WindowDelegator(){};
 
     void createWindow(SkSize windowSize,std::function<void ()> windowReadyTodrawCB,bool runOnTaskRunner=true);
     void closeWindow();
     void setWindowTittle(const char* titleString);
-    void commitDrawCall(std::string keyRef,sk_sp<SkPicture> pictureObj);
+    void commitDrawCall(std::string keyRef,PictureObject pictureObj);
     void setBasePicCommand(std::string keyName) {keyNameBasePicCommand_=keyName;}
 
   private:
     void onExposeHandler(RnsShell::Window* window);
     void windowWorkerThread();
     void createNativeWindow();
-    void renderToDisplay(std::string keyRef,sk_sp<SkPicture> pictureObj);
+    void renderToDisplay(std::string keyRef,PictureObject pictureObj);
 
     std::unique_ptr<RnsShell::WindowContext> windowContext_{nullptr};
     RnsShell::Window* window_{nullptr};
@@ -58,7 +65,7 @@ class WindowDelegator {
     SkSize windowSize_;
     bool windowActive{false};
 
-    std::map<std::string,sk_sp<SkPicture>> drawHistorybin_;
+    std::map<std::string,PictureObject> drawHistorybin_;
     std::string keyNameBasePicCommand_;
 };
 

--- a/ReactSkia/sdk/WindowDelegator.h
+++ b/ReactSkia/sdk/WindowDelegator.h
@@ -10,6 +10,7 @@
 #include <map>
 
 #include "include/core/SkCanvas.h"
+#include "include/core/SkPictureRecorder.h"
 
 #include "rns_shell/compositor/Compositor.h"
 #include "rns_shell/common/Window.h"
@@ -25,11 +26,13 @@ class WindowDelegator {
     WindowDelegator(){};
    ~WindowDelegator(){};
 
-    void createWindow(SkSize windowSize,std::function<void ()> windowReadyTodrawCB,std::function<void ()> forceFullScreenDraw=nullptr,bool runOnTaskRunner=true);
+    void createWindow(SkSize windowSize,std::function<void ()> windowReadyTodrawCB,bool runOnTaskRunner=true);
     void closeWindow();
     void setWindowTittle(const char* titleString);
     void commitDrawCall(std::string keyRef,sk_sp<SkPicture> pictureObj);
     void setBasePicCommand(std::string keyName) {keyNameBasePicCommand_=keyName;}
+
+  private:
     void onExposeHandler(RnsShell::Window* window);
     void windowWorkerThread();
     void createNativeWindow();
@@ -39,7 +42,6 @@ class WindowDelegator {
     RnsShell::Window* window_{nullptr};
     sk_sp<SkSurface>  backBuffer_;
     SkCanvas *windowDelegatorCanvas_{nullptr};
-    sk_sp<SkPicture>  fullSCreenPictureObj_;
 
 /*To fulfill OpenGl requirement of create & rendering to be handled from same thread context*/
     std::unique_ptr<RnsShell::TaskLoop> windowTaskRunner_{nullptr};
@@ -50,7 +52,6 @@ class WindowDelegator {
     std::thread workerThread_;
 
     std::function<void ()> windowReadyTodrawCB_{nullptr};
-    std::function<void ()> forceFullScreenDraw_{nullptr};
 
     RnsShell::PlatformDisplay::Type displayPlatForm_;
     int exposeEventID_{-1};

--- a/ReactSkia/sdk/WindowDelegator.h
+++ b/ReactSkia/sdk/WindowDelegator.h
@@ -24,6 +24,7 @@ namespace sdk {
 struct pictureCommand {
   std::vector<SkIRect> dirtyRect;
   sk_sp<SkPicture> pictureCommand;
+  bool invalidate;
 };
 
 typedef struct pictureCommand PictureObject;
@@ -36,22 +37,22 @@ class WindowDelegator {
     void createWindow(SkSize windowSize,std::function<void ()> windowReadyTodrawCB,bool runOnTaskRunner=true);
     void closeWindow();
     void setWindowTittle(const char* titleString);
-    void commitDrawCall(std::string pictureCommandKey,PictureObject pictureObj);
-    void setBasePicCommand(std::string keyName) {basePictureCommandKey_=keyName;}
+    void commitDrawCall(std::string pictureCommandKey,PictureObject pictureObj,bool batchCommit);
 
   private:
     void onExposeHandler(RnsShell::Window* window);
     void windowWorkerThread();
     void createNativeWindow();
-    void renderToDisplay(std::string pictureCommandKey,PictureObject pictureObj);
+    void renderToDisplay(std::string pictureCommandKey,PictureObject pictureObj,bool batchCommit);
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
-    void generateDirtyRect(std::vector<SkIRect> &dirtyRectVec ,std::vector<SkIRect> &componentDirtRectVec);
+    void generateDirtyRect(std::vector<SkIRect> &componentDirtRectVec);
+    bool supportsPartialUpdate_{false};
 #endif/*RNS_SHELL_PARTIAL_UPDATES*/
     std::unique_ptr<RnsShell::WindowContext> windowContext_{nullptr};
     RnsShell::Window* window_{nullptr};
     sk_sp<SkSurface>  backBuffer_;
     SkCanvas *windowDelegatorCanvas_{nullptr};
-    bool supportsPartialUpdate_{false};
+    std::vector<SkIRect> dirtyRectVec_;
 
 /*To fulfill OpenGl requirement of create & rendering to be handled from same thread context*/
     std::unique_ptr<RnsShell::TaskLoop> windowTaskRunner_{nullptr};
@@ -68,8 +69,7 @@ class WindowDelegator {
     SkSize windowSize_;
     bool windowActive{false};
 
-    std::map<std::string,PictureObject> componentCommandBin_;
-    std::string basePictureCommandKey_;
+    std::map<std::string,PictureObject> recentComponentCommandMap_;
 };
 
 } // namespace sdk

--- a/ReactSkia/sdk/WindowDelegator.h
+++ b/ReactSkia/sdk/WindowDelegator.h
@@ -7,6 +7,7 @@
 
 #include <semaphore.h>
 #include <thread>
+#include <vector>
 
 #include "include/core/SkCanvas.h"
 
@@ -27,9 +28,9 @@ class WindowDelegator {
     void createWindow(SkSize windowSize,std::function<void ()> windowReadyTodrawCB,std::function<void ()> forceFullScreenDraw=nullptr,bool runOnTaskRunner=true);
     void closeWindow();
     void setWindowTittle(const char* titleString);
-    void commitDrawCall();
 
-    SkCanvas *windowDelegatorCanvas{nullptr};
+    void commitDrawCall(sk_sp<SkPicture> pictureObj);
+    void setFullScreenPicture(sk_sp<SkPicture> pictureObj) {fullSCreenPictureObj_=pictureObj;}
 
   private:
     void onExposeHandler(RnsShell::Window* window);
@@ -40,6 +41,8 @@ class WindowDelegator {
     std::unique_ptr<RnsShell::WindowContext> windowContext_{nullptr};
     RnsShell::Window* window_{nullptr};
     sk_sp<SkSurface>  backBuffer_;
+    SkCanvas *windowDelegatorCanvas_{nullptr};
+    sk_sp<SkPicture>  fullSCreenPictureObj_;
 
 /*To fulfill OpenGl requirement of create & rendering to be handled from same thread context*/
     std::unique_ptr<RnsShell::TaskLoop> windowTaskRunner_{nullptr};
@@ -56,6 +59,8 @@ class WindowDelegator {
     int exposeEventID_{-1};
     SkSize windowSize_;
     bool windowActive{false};
+
+    std::vector<sk_sp<SkPicture>> drawHistorybin_;
 };
 
 } // namespace sdk

--- a/ReactSkia/sdk/WindowDelegator.h
+++ b/ReactSkia/sdk/WindowDelegator.h
@@ -29,8 +29,7 @@ class WindowDelegator {
     void closeWindow();
     void setWindowTittle(const char* titleString);
     void commitDrawCall(std::string keyRef,sk_sp<SkPicture> pictureObj);
-    void setFullScreenPicture(sk_sp<SkPicture> pictureObj) {fullSCreenPictureObj_=pictureObj;}
-  private:
+    void setBasePicCommand(std::string keyName) {keyNameBasePicCommand_=keyName;}
     void onExposeHandler(RnsShell::Window* window);
     void windowWorkerThread();
     void createNativeWindow();
@@ -59,6 +58,7 @@ class WindowDelegator {
     bool windowActive{false};
 
     std::map<std::string,sk_sp<SkPicture>> drawHistorybin_;
+    std::string keyNameBasePicCommand_;
 };
 
 } // namespace sdk

--- a/ReactSkia/sdk/WindowDelegator.h
+++ b/ReactSkia/sdk/WindowDelegator.h
@@ -37,7 +37,7 @@ class WindowDelegator {
     void createWindow(SkSize windowSize,std::function<void ()> windowReadyTodrawCB,bool runOnTaskRunner=true);
     void closeWindow();
     void setWindowTittle(const char* titleString);
-    void commitDrawCall(std::string pictureCommandKey,PictureObject pictureObj,bool batchCommit);
+    void commitDrawCall(std::string pictureCommandKey,PictureObject pictureObj,bool batchCommit=false);
 
   private:
     void onExposeHandler(RnsShell::Window* window);
@@ -47,6 +47,7 @@ class WindowDelegator {
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
     void generateDirtyRect(std::vector<SkIRect> &componentDirtRectVec);
     bool supportsPartialUpdate_{false};
+    std::vector<SkIRect> fullScreenDirtyRectVec_;
 #endif/*RNS_SHELL_PARTIAL_UPDATES*/
     std::unique_ptr<RnsShell::WindowContext> windowContext_{nullptr};
     RnsShell::Window* window_{nullptr};

--- a/ReactSkia/sdk/WindowDelegator.h
+++ b/ReactSkia/sdk/WindowDelegator.h
@@ -44,6 +44,7 @@ class WindowDelegator {
     void windowWorkerThread();
     void createNativeWindow();
     void renderToDisplay(std::string pictureCommandKey,PictureObject pictureObj);
+    void appendDirtyRect(std::vector<SkIRect> &dirtyRectVec ,std::vector<SkIRect> &componentDirtRectVec);
 
     std::unique_ptr<RnsShell::WindowContext> windowContext_{nullptr};
     RnsShell::Window* window_{nullptr};
@@ -65,7 +66,7 @@ class WindowDelegator {
     SkSize windowSize_;
     bool windowActive{false};
 
-    std::map<std::string,PictureObject> drawHistorybin_;
+    std::map<std::string,PictureObject> componentCommandBin_;
     std::string basePictureCommandKey_;
 };
 

--- a/rns_shell/common/WindowContext.cpp
+++ b/rns_shell/common/WindowContext.cpp
@@ -21,10 +21,12 @@ WindowContext::WindowContext(const DisplayParams& params)
 
 WindowContext::~WindowContext() {}
 
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
 bool WindowContext::supportsPartialUpdate() {
     RNS_LOG_DEBUG("Support for Swapbuffer with damage rect : " << hasSwapBuffersWithDamage() <<
                   " Support for Copy buffer : " <<  hasBufferCopy());
     return (hasSwapBuffersWithDamage() || hasBufferCopy());
 }
+#endif/*RNS_SHELL_PARTIAL_UPDATES*/
 
 }   //namespace RnsShell

--- a/rns_shell/common/WindowContext.cpp
+++ b/rns_shell/common/WindowContext.cpp
@@ -21,4 +21,10 @@ WindowContext::WindowContext(const DisplayParams& params)
 
 WindowContext::~WindowContext() {}
 
+bool WindowContext::supportsPartialUpdate() {
+    RNS_LOG_DEBUG("Support for Swapbuffer with damage rect : " << hasSwapBuffersWithDamage() <<
+                  " Support for Copy buffer : " <<  hasBufferCopy());
+    return (hasSwapBuffersWithDamage() || hasBufferCopy());
+}
+
 }   //namespace RnsShell

--- a/rns_shell/common/WindowContext.h
+++ b/rns_shell/common/WindowContext.h
@@ -50,6 +50,7 @@ public:
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
     virtual bool hasSwapBuffersWithDamage() = 0; // Support for swapping/flipping multiple regions of backbuffer to frontbuffer
     virtual bool hasBufferCopy() = 0; // Support for copying frontbuffer to backbuffer. Required/used only when hasSwapBuffersWithDamage is false
+    bool supportsPartialUpdate();
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
     virtual int32_t bufferAge() = 0; // Age of current backbuffer
 #endif

--- a/rns_shell/compositor/Compositor.cpp
+++ b/rns_shell/compositor/Compositor.cpp
@@ -54,9 +54,7 @@ Compositor::Compositor(Client& client, PlatformDisplayID displayID, SkSize& view
         attributes_.needsResize = !viewportSize.isEmpty();
     }
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
-    supportPartialUpdate_ = windowContext_->hasSwapBuffersWithDamage() || windowContext_->hasBufferCopy();
-    RNS_LOG_DEBUG("Support for Swapbuffer with damage rect : " << windowContext_->hasSwapBuffersWithDamage() <<
-                  " Support for Copy buffer : " <<  windowContext_->hasBufferCopy());
+    supportPartialUpdate_ = windowContext_->supportsPartialUpdate();
 #endif
     RNS_LOG_DEBUG("Native Window Handle : " << nativeWindowHandle_ << " Window Context : " << windowContext_.get() << "Back Buffer : " << backBuffer_.get());
 }


### PR DESCRIPTION
1. Window Delegator modified to work with picture object
2. Window delegator's client [OSK or Alert], Needs to record picture command + dirty REct and pass it to WIndow Delegator to Render
3. Window Delegator Maintain history of commands and playback the commands from the history with respective  dirtyRect , when buffer Age issue is seen
4. Commands are stored as key value pair, where key denotes the portion/component of window
5. Added Dirty Rect Based rendering
6. Considered Partial update support by the system

