### PR TITLE
Added support for bufferAge based partial update

### DIFF
--- a/rns_shell/BUILD.gn
+++ b/rns_shell/BUILD.gn
@@ -26,6 +26,9 @@ config("rns_shell_config") {
     } 
     if(rns_enable_partial_updates) {
       defines += ["USE_RNS_SHELL_PARTIAL_UPDATES"]
+      if(gl_has_gpu && rns_enable_buffer_age_partial_updates) {
+        defines += ["ENABLE_RNS_SHELL_BUFFER_AGE"]
+      }
     }
   }
 

--- a/rns_shell/compositor/Compositor.cpp
+++ b/rns_shell/compositor/Compositor.cpp
@@ -115,6 +115,52 @@ SkRect Compositor::beginClip(PaintContext& context, bool useClipRegion) {
     return clipBound;
 }
 
+#if USE(RNS_SHELL_PARTIAL_UPDATES) && ENABLE(RNS_SHELL_BUFFER_AGE)
+SkRect Compositor::beginClip() {
+    SkRect clipBound = SkRect::MakeEmpty();
+    int32_t bufferAge = windowContext_->bufferAge();
+
+    if(surfaceDamage_.size() == 0)
+        return clipBound;
+
+    SkPath clipPath = SkPath();
+    for (auto& rect : surfaceDamage_) {
+        RNS_LOG_DEBUG("Add Damage " << rect.x() << " " << rect.y() << " " << rect.width() << " " << rect.height());
+        clipPath.addRect(rect.left(), rect.top(), rect.right(), rect.bottom());
+    }
+
+    if(bufferAge == 1) // Buffer is up to date. No need of additional history
+        goto safeClipReturn;
+    else if(bufferAge == 0 || // Buffer is being used for the first time or has been reset
+            (bufferAge > frameDamageHistory_.size())) { // dont have enough history, so draw full screen
+        // Need full redraw, so ignore all dirty rects & clippath then set it to whole screen
+        int width = attributes_.viewportSize.width();
+        int height = attributes_.viewportSize.height();
+        surfaceDamage_.clear();
+        clipPath.reset();
+        Layer::addDamageRect(surfaceDamage_, {0, 0, width, height});
+        clipPath.addRect(0, 0, width, height);
+    } else if(bufferAge > 1) {
+        auto frameDamages = frameDamageHistory_.rbegin();
+        FrameDamages &dirtyRects = (*frameDamages);
+        for (auto age = bufferAge - 1; frameDamages != frameDamageHistory_.rend() && age > 0; ++frameDamages, --age) {
+            dirtyRects = *frameDamages;
+            for (auto& rect : dirtyRects) {
+                RNS_LOG_DEBUG("Buffer Age[" << bufferAge << "], History Index[" << age << "] : Aditional Damage [" <<
+                    rect.x() << "," << rect.y() << "," << rect.width() << "," << rect.height() << "]");
+              Layer::addDamageRect(surfaceDamage_, rect);
+              clipPath.addRect(rect.left(), rect.top(), rect.right(), rect.bottom());
+            }
+        }
+    }
+
+safeClipReturn:
+    backBuffer_->getCanvas()->clipPath(clipPath);
+    clipBound = clipPath.getBounds();
+    return clipBound;
+}
+#endif // USE(RNS_SHELL_PARTIAL_UPDATES) && ENABLE(RNS_SHELL_BUFFER_AGE)
+
 void Compositor::renderLayerTree() {
 
     if(!windowContext_)
@@ -149,9 +195,10 @@ void Compositor::renderLayerTree() {
         auto canvas = backBuffer_->getCanvas();
         SkAutoCanvasRestore save(canvas, true);
         SkRect clipBound = SkRect::MakeEmpty();
+
         PaintContext paintContext = {
             canvas,  // canvas
-            surfaceDamage_, // damage rects
+            surfaceDamage_, // Damage rects for current frame including damage history
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
             supportPartialUpdate_,
 #endif
@@ -160,7 +207,12 @@ void Compositor::renderLayerTree() {
             {0,0} //scrollOffset is zero for rootLayer
         };
         RNS_PROFILE_API_OFF("Render Tree Pre-Paint", rootLayer_.get()->prePaint(paintContext));
+#if USE(RNS_SHELL_PARTIAL_UPDATES) && ENABLE(RNS_SHELL_BUFFER_AGE)
+        FrameDamages currentFrameDamages(surfaceDamage_); // Copy dirty rects from current frame
+        clipBound = beginClip();
+#else
         clipBound = beginClip(paintContext);
+#endif
         /* Check if paint required*/
         if(!rootLayer_.get()->needsPainting(paintContext)) return;
 #ifdef RNS_SHELL_HAS_GPU_SUPPORT
@@ -186,6 +238,16 @@ void Compositor::renderLayerTree() {
 #endif
         RNS_PROFILE_API_OFF("SwapBuffers", windowContext_->swapBuffers(surfaceDamage_));
         client_.didRenderFrame();
+
+#if USE(RNS_SHELL_PARTIAL_UPDATES) && ENABLE(RNS_SHELL_BUFFER_AGE)
+        // Add damage to history
+        if (frameDamageHistory_.size() >= MAX_FRAME_DAMAGE_HISTORY) {
+          FrameDamages damages = frameDamageHistory_.front();
+          damages.clear();
+          frameDamageHistory_.pop_front();
+        }
+        frameDamageHistory_.push_back(currentFrameDamages);
+#endif
     }
 }
 

--- a/rns_shell/compositor/Compositor.h
+++ b/rns_shell/compositor/Compositor.h
@@ -16,7 +16,7 @@
 #include "layers/Layer.h"
 
 #define RNS_TARGET_FPS_US 16666.7 // In Microseconds
-#define MAX_FRAME_DAMAGE_HISTORY 5
+#define RNS_SHELL_MAX_FRAME_DAMAGE_HISTORY 5
 
 namespace RnsShell {
 

--- a/rns_shell/compositor/Compositor.h
+++ b/rns_shell/compositor/Compositor.h
@@ -7,6 +7,8 @@
 */
 #pragma once
 
+#include <list>
+
 #include "third_party/skia/include/core/SkRect.h"
 
 #include "WindowContext.h"
@@ -14,6 +16,7 @@
 #include "layers/Layer.h"
 
 #define RNS_TARGET_FPS_US 16666.7 // In Microseconds
+#define MAX_FRAME_DAMAGE_HISTORY 5
 
 namespace RnsShell {
 
@@ -54,7 +57,9 @@ private:
 
     void createWindowContext();
     void renderLayerTree();
-
+#if USE(RNS_SHELL_PARTIAL_UPDATES) && ENABLE(RNS_SHELL_BUFFER_AGE)
+    SkRect beginClip();
+#endif
     std::mutex isMutating; // Lock the renderLayer tree while updating and rendering
 
     Client& client_;
@@ -67,7 +72,9 @@ private:
     bool supportPartialUpdate_;
 #endif
     std::vector<SkIRect> surfaceDamage_;
-
+#if USE(RNS_SHELL_PARTIAL_UPDATES) && ENABLE(RNS_SHELL_BUFFER_AGE)
+    std::list<FrameDamages> frameDamageHistory_;
+#endif
     struct {
         //Lock lock;
         SkSize viewportSize;

--- a/rns_shell/compositor/layers/Layer.cpp
+++ b/rns_shell/compositor/layers/Layer.cpp
@@ -14,9 +14,11 @@ namespace RnsShell {
 
 #if USE(RNS_SHELL_PARTIAL_UPDATES)
 void Layer::addDamageRect(PaintContext& context, SkIRect dirtyAbsFrameRect) {
-    std::vector<SkIRect>& damageRectList = context.damageRect;
-    bool checkIfAlreadyCovered = true;
+    addDamageRect(context.damageRect, dirtyAbsFrameRect);
+}
 
+void Layer::addDamageRect(FrameDamages& damageRectList, SkIRect dirtyAbsFrameRect) {
+    bool checkIfAlreadyCovered = true;
     for (auto it = damageRectList.begin(); it != damageRectList.end(); it++) {
         // Check 1 : If new dirty rect fully covers any of existing dirtyRect in the list then remove them from vector
         SkIRect &dirtRect = *it;

--- a/rns_shell/compositor/layers/Layer.h
+++ b/rns_shell/compositor/layers/Layer.h
@@ -45,6 +45,7 @@ enum LayerInvalidateMask {
 
 typedef std::vector<std::shared_ptr<Layer> > LayerList;
 using SharedLayer = std::shared_ptr<Layer>;
+using FrameDamages = std::vector<SkIRect>;
 
 struct PaintContext {
     SkCanvas* canvas;
@@ -128,14 +129,17 @@ public:
 
     const bool masksToBounds() const { return masksToBounds_; }
     void setMasksTotBounds(bool masksToBounds) { masksToBounds_ = masksToBounds; }
-
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
+    static void addDamageRect(FrameDamages& damageRectList, SkIRect dirtyAbsFrameRect);
+#endif
 public:
     friend class PictureLayer;
     friend class ScrollLayer;
 
 protected:
+#if USE(RNS_SHELL_PARTIAL_UPDATES)
     static void addDamageRect(PaintContext& context, SkIRect dirtyAbsFrameRect);
-
+#endif
 private:
     static uint64_t nextUniqueId();
 

--- a/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.cpp
+++ b/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.cpp
@@ -482,7 +482,7 @@ int32_t GLWindowContextEGL::getBufferAge() {
   if(false == eglQuerySurface(platformDisplay_.eglDisplay(), glSurface_, EGL_BUFFER_AGE_EXT, &bufferAge)) {
     RNS_LOG_ERROR("Egl Query Surface(EGL_BUFFER_AGE_EXT) Error : " << eglErrorString());
   } else {
-    RNS_LOG_ERROR("Buffer Age of Current backBuffer of surface : " << bufferAge);
+    RNS_LOG_INFO("Buffer Age of Current backBuffer of surface : " << bufferAge);
   }
 
   return bufferAge;

--- a/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.cpp
+++ b/rns_shell/platform/graphics/gl/egl/GLWindowContextEGL.cpp
@@ -478,8 +478,13 @@ std::vector<EGLint> GLWindowContextEGL::rectsToInts(EGLDisplay display, EGLSurfa
 
 int32_t GLWindowContextEGL::getBufferAge() {
   EGLint bufferAge = 0;
-  eglQuerySurface(platformDisplay_.eglDisplay(), glSurface_, EGL_BUFFER_AGE_EXT, &bufferAge);
-  RNS_LOG_ERROR("Buffer Age of Current backBuffer of surface : " << bufferAge);
+
+  if(false == eglQuerySurface(platformDisplay_.eglDisplay(), glSurface_, EGL_BUFFER_AGE_EXT, &bufferAge)) {
+    RNS_LOG_ERROR("Egl Query Surface(EGL_BUFFER_AGE_EXT) Error : " << eglErrorString());
+  } else {
+    RNS_LOG_ERROR("Buffer Age of Current backBuffer of surface : " << bufferAge);
+  }
+
   return bufferAge;
 }
 

--- a/rns_shell/platform/graphics/x11/PlatformDisplayX11.cpp
+++ b/rns_shell/platform/graphics/x11/PlatformDisplayX11.cpp
@@ -57,13 +57,13 @@ PlatformDisplayX11::~PlatformDisplayX11() {
 void PlatformDisplayX11::initializeEGLDisplay()
 {
 #if defined(EGL_KHR_platform_x11)
-    const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
+    const char* extensions = eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
     if (GLWindowContextEGL::isExtensionSupported(extensions, "EGL_KHR_platform_base")) {
         if (auto* getPlatformDisplay = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(eglGetProcAddress("eglGetPlatformDisplay")))
             eglDisplay_ = getPlatformDisplay(EGL_PLATFORM_X11_KHR, display_, nullptr);
     } else if (GLWindowContextEGL::isExtensionSupported(extensions, "EGL_EXT_platform_base")) {
         if (auto* getPlatformDisplay = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(eglGetProcAddress("eglGetPlatformDisplayEXT")))
-            eglDisplay_ = getPlatformDisplay(EGL_PLATFORM_X11_KHR, display_, nullptr);
+            eglDisplay_ = getPlatformDisplay(EGL_PLATFORM_X11_EXT, display_, nullptr);
     } else
 #endif
     eglDisplay_ = eglGetDisplay(display_);

--- a/rns_shell/rns_shell.gni
+++ b/rns_shell/rns_shell.gni
@@ -26,6 +26,9 @@ declare_args() {
     # Use bitmap for scroll layer.
     # Enable if scroll layer children do not have any runtime updates,to improve performance.
     rns_enable_scroll_layer_bitmap = false
+
+    # If GPU enabled system doesn't support swapbuffer_with_damage or damage_region extensions but supports buffer_age extension, then this can be enabled to improve rendering.
+    rns_enable_buffer_age_partial_updates = false
   }
 }
 


### PR DESCRIPTION
If a GPU enabled system doesn't support swapbuffer_with_damage or damage_region extensions
but supports buffer_age extension, then we can save the damages of every frame and do partial update using buffer age of current backbuffer.

This feature is disabled by default and can be enabled using configuration value rns_enable_buffer_age_partial_updates=true