### PR TITLE
Improvements in layer creation and onPaint function handling

### DIFF
--- a/ReactSkia/components/RSkComponent.h
+++ b/ReactSkia/components/RSkComponent.h
@@ -75,9 +75,9 @@ struct Component {
 
 class RSkComponent;
 
-class RSkComponent : public RnsShell::Layer , public SpatialNavigator::Container, public std::enable_shared_from_this<RSkComponent>  {
+class RSkComponent : public SpatialNavigator::Container, public std::enable_shared_from_this<RSkComponent>  {
  public:
-  RSkComponent(const ShadowView &shadowView);
+  RSkComponent(const ShadowView &shadowView, RnsShell::LayerType layerType = LAYER_TYPE_PICTURE);
   RSkComponent(RSkComponent &&) = default;
   RSkComponent &operator=(RSkComponent &&) = default;
 
@@ -126,11 +126,12 @@ class RSkComponent : public RnsShell::Layer , public SpatialNavigator::Container
   sk_sp<SkPicture> getPicture(PictureType type=PictureTypeAll);
  private:
   // RnsShell::Layer implementations
-  void onPaint(SkCanvas*) override;
+  void onPaint(SkCanvas*);
 
  private:
   RSkComponent *parent_;
   std::shared_ptr<RnsShell::Layer> layer_;
+  RnsShell::LayerType layerType_{LAYER_TYPE_PICTURE};
   Component component_;
 
   typedef Layer INHERITED;

--- a/ReactSkia/components/RSkComponent.h
+++ b/ReactSkia/components/RSkComponent.h
@@ -133,8 +133,6 @@ class RSkComponent : public SpatialNavigator::Container, public std::enable_shar
   std::shared_ptr<RnsShell::Layer> layer_;
   RnsShell::LayerType layerType_{LAYER_TYPE_PICTURE};
   Component component_;
-
-  typedef Layer INHERITED;
 };
 
 } // namespace react

--- a/ReactSkia/components/RSkComponentScrollView.cpp
+++ b/ReactSkia/components/RSkComponentScrollView.cpp
@@ -18,7 +18,7 @@ namespace facebook {
 namespace react {
 
 RSkComponentScrollView::RSkComponentScrollView(const ShadowView &shadowView)
-    : RSkComponent(shadowView) {
+    : RSkComponent(shadowView, LAYER_TYPE_SCROLL) {
 }
 
 RSkComponentScrollView::~RSkComponentScrollView() {

--- a/ReactSkia/components/RSkComponentText.cpp
+++ b/ReactSkia/components/RSkComponentText.cpp
@@ -23,7 +23,7 @@ namespace facebook {
 namespace react {
 
 RSkComponentText::RSkComponentText(const ShadowView &shadowView)
-    : RSkComponent(shadowView) {}
+    : RSkComponent(shadowView, LAYER_TYPE_DEFAULT) {}
 
 RnsShell::LayerInvalidateMask RSkComponentText::updateComponentProps(SharedProps newviewProps,bool forceUpadte) {
   return RnsShell::LayerInvalidateNone;
@@ -32,7 +32,7 @@ RnsShell::LayerInvalidateMask RSkComponentText::updateComponentProps(SharedProps
 void RSkComponentText::OnPaint(SkCanvas *canvas) {}
 
 RSkComponentRawText::RSkComponentRawText(const ShadowView &shadowView)
-    : RSkComponent(shadowView) {}
+    : RSkComponent(shadowView, LAYER_TYPE_DEFAULT) {}
 
 RnsShell::LayerInvalidateMask RSkComponentRawText::updateComponentProps(SharedProps newviewProps,bool forceUpadte) {
   return RnsShell::LayerInvalidateNone;
@@ -41,7 +41,7 @@ RnsShell::LayerInvalidateMask RSkComponentRawText::updateComponentProps(SharedPr
 void RSkComponentRawText::OnPaint(SkCanvas *canvas) {}
 
 RSkComponentParagraph::RSkComponentParagraph(const ShadowView &shadowView)
-    : RSkComponent(shadowView)
+    : RSkComponent(shadowView, LAYER_TYPE_DEFAULT)
     , expectedAttachmentCount(0)
     , currentAttachmentCount(0){}
 

--- a/rns_shell/compositor/layers/Layer.cpp
+++ b/rns_shell/compositor/layers/Layer.cpp
@@ -74,7 +74,8 @@ SharedLayer Layer::Create(Client& layerClient, LayerType type) {
         case LAYER_TYPE_SCROLL:
             return std::make_shared<ScrollLayer>(layerClient);
         case LAYER_TYPE_DEFAULT:
-            return std::make_shared<Layer>(layerClient, LAYER_TYPE_DEFAULT);
+        case LAYER_TYPE_VIRTUAL:
+            return std::make_shared<Layer>(layerClient, type);
         default:
             RNS_LOG_ASSERT(false, "Unknown Layer type to create");
             return nullptr;
@@ -274,6 +275,14 @@ void Layer::paint(PaintContext& context) {
     }
 
     paintChildren(context);
+}
+
+void Layer::registerOnPaint(LayerOnPainFunc paintFunc) {
+  if(type_ == LAYER_TYPE_DEFAULT) {
+    onPaint_ = paintFunc;
+  } else {
+    RNS_LOG_WARN("registerOnPaint is used only for DEFAULT layer type");
+  }
 }
 
 bool Layer::hasAncestor(const Layer* ancestor) const {

--- a/rns_shell/compositor/layers/Layer.cpp
+++ b/rns_shell/compositor/layers/Layer.cpp
@@ -74,8 +74,9 @@ SharedLayer Layer::Create(Client& layerClient, LayerType type) {
         case LAYER_TYPE_SCROLL:
             return std::make_shared<ScrollLayer>(layerClient);
         case LAYER_TYPE_DEFAULT:
+            return std::make_shared<Layer>(layerClient, LAYER_TYPE_DEFAULT);
         default:
-            RNS_LOG_ASSERT(false, "Default layers can be created only from RSkComponent constructor");
+            RNS_LOG_ASSERT(false, "Unknown Layer type to create");
             return nullptr;
     }
 }
@@ -232,7 +233,8 @@ void Layer::paintSelf(PaintContext& context) {
     RNS_GET_TIME_STAMP_US(start);
 #endif
 
-    this->onPaint(context.canvas);
+    if(onPaint_)
+      onPaint_(context.canvas);
 
 #if !defined(GOOGLE_STRIP_LOG) || (GOOGLE_STRIP_LOG <= INFO)
     RNS_GET_TIME_STAMP_US(end);

--- a/rns_shell/compositor/layers/Layer.h
+++ b/rns_shell/compositor/layers/Layer.h
@@ -47,6 +47,7 @@ enum LayerInvalidateMask {
 typedef std::vector<std::shared_ptr<Layer> > LayerList;
 using SharedLayer = std::shared_ptr<Layer>;
 using FrameDamages = std::vector<SkIRect>;
+using LayerOnPainFunc = std::function<void(SkCanvas*)>;
 
 struct PaintContext {
     SkCanvas* canvas;
@@ -93,7 +94,7 @@ public:
     virtual ~Layer() {};
 
     Client& client() const { return *client_; }
-    void setClient(Client& client) { client_ = &client; } // Used for Default Layer Type TODO: Need to remove this once we introduce Paintclient for default Layer.
+    void registerOnPaint(LayerOnPainFunc paintFunc) { onPaint_ = paintFunc; } // Used for Default Layer Type
 
     Layer* rootLayer();
     Layer* parent() { return parent_; }
@@ -118,7 +119,6 @@ public:
     virtual void paintChildren(PaintContext& context);
     virtual void prePaint(PaintContext& context, bool forceChildrenLayout = false);
     virtual void paint(PaintContext& context);
-    virtual void onPaint(SkCanvas*) {}
 
     SkIRect& absoluteFrame() { return absFrame_; }
     const SkIRect& getFrame() const { return frame_; }
@@ -151,6 +151,7 @@ private:
     void setSkipParentMatrix(bool skipParentMatrix) {skipParentMatrix_ = skipParentMatrix;}
     void applyLayerOpacity(PaintContext& context);
     void applyLayerTransformMatrix(PaintContext& context);
+    LayerOnPainFunc onPaint_{nullptr}; // Used for LAYER_TYPE_DEFAULT only
 
     SkIRect getFrameBoundsWithShadow();
 

--- a/rns_shell/compositor/layers/Layer.h
+++ b/rns_shell/compositor/layers/Layer.h
@@ -30,7 +30,8 @@ namespace RnsShell {
 class Layer;
 
 enum LayerType {
-    LAYER_TYPE_DEFAULT = 0, // Default layer type which which will use component specific APIs to paint.
+    LAYER_TYPE_DEFAULT = 0, // Default layer type will need to register a paint functions using registerOnPaint.
+    LAYER_TYPE_VIRTUAL, // Layer without any paint function. Used to maintain frame and properties..
     LAYER_TYPE_PICTURE, // SkPiture based layer.
     LAYER_TYPE_SCROLL, // Scrolling functionality based layer.
     LAYER_TYPE_TEXTURED, // SkTexture based layer.
@@ -94,7 +95,7 @@ public:
     virtual ~Layer() {};
 
     Client& client() const { return *client_; }
-    void registerOnPaint(LayerOnPainFunc paintFunc) { onPaint_ = paintFunc; } // Used for Default Layer Type
+    void registerOnPaint(LayerOnPainFunc paintFunc);// Used for Default Layer Type
 
     Layer* rootLayer();
     Layer* parent() { return parent_; }


### PR DESCRIPTION
## Description

<!-- OR, if you're implementing a new feature: -->

Added `registerOnPaint()` that allows to register onPaint function for `LAYER_TYPE_DEFAULT` layer. Hence RSkComponent need not to be derived class of Layer Class anymore. 

Now component's layers will be created based on `layerType_ `private member instead of component name. Components need to pass `layerType` in constructor if it requires layer type other than `LAYER_TYPE_PICTURE`.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Linux   |    ✅     |
| iOS     |    ❌     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [✅ ] I have tested this on Ubuntu  OS