### PR TITLE
Write call back is missing in POST method

### DIFF
--- a/ReactSkia/sdk/CurlNetworking.cpp
+++ b/ReactSkia/sdk/CurlNetworking.cpp
@@ -184,6 +184,10 @@ bool CurlNetworking::preparePostRequest(shared_ptr<CurlRequest> curlRequest, fol
   /* get verbose debug output please */
   curl_easy_setopt(curlRequest->handle, CURLOPT_POSTFIELDSIZE, (long)dataSize);
   curl_easy_setopt(curlRequest->handle, CURLOPT_COPYPOSTFIELDS, dataPtr);
+    // ResponseWrite callback and user data
+  curl_easy_setopt(curlRequest->handle, CURLOPT_WRITEDATA, curlRequest.get());
+  curl_easy_setopt(curlRequest->handle, CURLOPT_WRITEFUNCTION, writeCallbackCurlWrapper);
+
   status = true;
   return status;
 }


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #1 Write callback added to the POST method in CURL SDK

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Linux   |    ✅   |
| iOS     |    ❌     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a Ubuntu
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
